### PR TITLE
fix: skip PinLock when /api/pin-info is unavailable

### DIFF
--- a/src/components/PinLock.tsx
+++ b/src/components/PinLock.tsx
@@ -25,7 +25,7 @@ export function PinLock({ children }: { children: React.ReactNode }) {
         }
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch(() => { setEnabled(false); setUnlocked(true); setLoading(false); });
   }, [unlocked]);
 
   const handleDigit = useCallback((d: string) => {


### PR DESCRIPTION
## Summary
- When maw-js server doesn't have `/api/pin-info` endpoint, `PinLock` defaults to `enabled=true` and blocks all UI access
- This fix auto-unlocks when the fetch fails (404/network error), so offices without PIN configured can use the UI normally

## The Problem
`PinLock.tsx` line 9 sets `enabled` to `true` by default. The `.catch()` on line 28 only sets `loading: false` but leaves `enabled: true`. Result: PIN screen with no way to unlock.

## The Fix
One line change in `.catch()`: also set `enabled=false` and `unlocked=true` when the API isn't available.

## Test
- Confirmed working on a maw-js instance without PIN API endpoints
- UI loads directly without PIN prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)