### PR TITLE
chore(ci): add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: build
+
+# Lens CI: every PR and every push to main builds the lens and uploads
+# the dist artifact. The artifact is what `maw ui` (future, mawjs-oracle's
+# repo) will consume — same bytes from CI as you'd get from `npx vite build`
+# locally.
+#
+# Why this exists: PR #8 caught a "fresh clones cannot build" bug where
+# package.json declared `mqtt` but no lockfile pinned it. The build would
+# only work where someone had already run `npm install`. This workflow
+# guards against the same class of regression — if main cannot be built
+# from a fresh checkout, CI fails before merge.
+#
+# Pattern lesson: ground BEFORE shipping. CI is the automated form of
+# "ground before shipping" — the green check IS the curl. See
+# ψ/memory/feedback_ground_before_proposing.md (mawui-oracle vault).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel in-progress runs when a new commit lands on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (node 20)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build lens (vite)
+        run: npx vite build
+
+      - name: Show build output
+        run: |
+          echo "::group::dist tree"
+          find dist -type f -printf '%p  %s bytes\n' | sort
+          echo "::endgroup::"
+          echo "::group::dist size summary"
+          du -sh dist
+          du -sh dist/assets
+          echo "::endgroup::"
+
+      - name: Upload lens artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lens-dist
+          path: dist/
+          retention-days: 14
+          if-no-files-found: error


### PR DESCRIPTION
## Summary

First CI for `maw-ui`. Builds the lens on every PR and every push to `main`, uploads `dist/` as a 14-day artifact.

This is the missing fourth piece of the night's work:
1. ✅ Schema v2 contacts (records collabs across vaults)
2. ✅ PR #8 — drift fix (lens reads canonical v1 endpoints)
3. ✅ PR #9 — identity badge (`👁 <node>` in header)
4. **This PR** — CI that catches the next regression *before* merge

## Why it exists

PR #8 caught a "fresh clones cannot build" bug: `package.json` declared `mqtt` but no lockfile pinned it, so the build only worked where someone had already run `npm install`. We fixed it manually. CI ensures the **next** version of that bug never reaches main.

## Workflow shape (60 lines, single job, ~20s of YAML logic)

```yaml
on: pull_request + push to main
concurrency: cancel-in-progress on same ref
job: build
  steps:
    - checkout
    - setup-node@v4 (node 20, npm cache)
    - npm ci                          # uses lockfile from PR #8
    - npx vite build
    - print dist tree + size summary
    - upload-artifact (dist/, 14d, error if empty)
```

No tests, no lint, no typecheck — those don't exist in the repo yet. Adding them in the same PR would be scope creep. Each can be its own follow-up workflow once it earns its keep.

## "Match the command `maw ui`"

Right now `maw ui` doesn't exist as a command in maw-js (verified — `maw --help` lists `maw serve [port]` for the API server, no UI command). The artifact upload is the **bridge**: when mawjs-oracle adds a `maw ui` command, it can `gh run download lens-dist` to fetch the same bytes CI just produced. Same `dist/` from CI as `npx vite build` locally — single source of truth.

Two follow-ups this enables:
- maw-js side: add `maw ui [--from-ci|--local]` command that serves `dist/` over HTTP
- maw-ui side: add a `deploy.yml` workflow that publishes the artifact to a stable URL (CF Pages? GitHub Pages?) on merge to main

Both stay out of scope for this PR — discipline of "smallest meaningful step" still holds.

## Stacked on #9

Base: `feat/lens-v1.1-identity-badge` (PR #9). Reason: this workflow uses `npm ci` which needs the `package-lock.json` introduced in PR #8, and the badge from #9 lives on top. Merge order: **#8 → #9 → this PR**.

After all three land, every future PR runs CI from minute one.

## Test plan

- [ ] CI run on this PR is itself the test (the workflow validates itself before merge)
- [ ] Confirm green check appears on the PR
- [ ] Inspect uploaded `lens-dist` artifact in Actions run — should contain `dist/index.html`, all `dist/assets/*.js`, and the 17 `*.html` entry points
- [ ] After merge to main, push any tiny commit and verify CI fires automatically

## Co-credits

- `mawui-oracle` (oracle-world) — wrote the workflow
- `mawjs-oracle` (oracle-world hub) — co-architected the night's "ground before shipping" rule that this CI now automates

🤖 Written by Oracles. Rule 6: Oracle Never Pretends to Be Human.

Part of `collabs.lens-v1` — closing the loop. `ground BEFORE proposing → ground BEFORE patching → CI BEFORE shipping`. Same rule, three timepoints, fully automated.