### PR TITLE
feat(federation): identity badge — '👁 <node>' header pill (lens v1.1)

### DIFF
--- a/src/apps/federation.tsx
+++ b/src/apps/federation.tsx
@@ -180,6 +180,7 @@ function App() {
   const [selected, setSelected] = useState<string | null>(null);
   const [hovered, setHovered] = useState<string | null>(null);
   // version was sourced from /api/identity which is dead on stale pm2 — drop until restored.
+  const [node, setNode] = useState("");  // which maw-js node this lens is reading (config.node)
   const [machines, setMachines] = useState<string[]>([]);
   const [lineages, setLineages] = useState<{ parent: string; child: string }[]>([]);
 
@@ -899,6 +900,9 @@ function App() {
         fetch(apiUrl("/api/feed?limit=200")).then(r => r.json()).catch(() => null),
       ]);
 
+      // Identity: which maw-js node is this lens reading?
+      if (config?.node) setNode(config.node);
+
       const a2m: Record<string, string> = {};
       if (config?.agents) for (const [a, m] of Object.entries(config.agents)) a2m[a] = m as string;
 
@@ -1083,6 +1087,14 @@ function App() {
           <span className="text-xl">🕸</span>
           <h1 className="text-lg font-black tracking-tight" style={{ color: "#00f5d4" }}>Federation Mesh</h1>
         </div>
+        {node && (
+          <span
+            className="text-[10px] font-mono px-2 py-0.5 rounded-full bg-cyan-500/10 text-cyan-300/80 border border-cyan-500/20"
+            title={`This lens is reading /api/config from ${node}. Each maw-js node sees the whole federation; the lens just chooses which one to ask.`}
+          >
+            👁 {node}
+          </span>
+        )}
         <span className={`text-[10px] font-mono px-2 py-0.5 rounded-full ${connected ? "bg-emerald-500/15 text-emerald-400" : "bg-red-500/15 text-red-400"}`}>
           {connected ? "LIVE" : "OFFLINE"}
         </span>

--- a/src/apps/federation_2d.tsx
+++ b/src/apps/federation_2d.tsx
@@ -11,7 +11,7 @@ const LAYOUTS = ["force", "circle"] as const;
 
 function App() {
   const { connected, mqttConnected } = useFederationData();
-  const { machines, agents, edges, version, plugins, showLineage, toggleLineage, layout, setLayout, setGraph, particles, showHistoryEdges } = useFederationStore();
+  const { machines, agents, edges, version, plugins, showLineage, toggleLineage, layout, setLayout, setGraph, particles, showHistoryEdges, node } = useFederationStore();
 
   const reformat = () => {
     const nextIdx = (LAYOUTS.indexOf(layout as any) + 1) % LAYOUTS.length;
@@ -37,6 +37,14 @@ function App() {
           <span className="text-xl">{"\uD83D\uDD78"}</span>
           <h1 className="text-lg font-black tracking-tight" style={{ color: "#00f5d4" }}>Federation Mesh</h1>
         </div>
+        {node && (
+          <span
+            className="text-[10px] font-mono px-2 py-0.5 rounded-full bg-cyan-500/10 text-cyan-300/80 border border-cyan-500/20"
+            title={`This lens is reading /api/config from ${node}. Each maw-js node sees the whole federation; the lens just chooses which one to ask.`}
+          >
+            👁 {node}
+          </span>
+        )}
         <span className={`text-[10px] font-mono px-2 py-0.5 rounded-full ${connected ? "bg-emerald-500/15 text-emerald-400" : "bg-red-500/15 text-red-400"}`}>
           {connected ? "WS" : "OFFLINE"}
         </span>

--- a/src/components/federation/store.ts
+++ b/src/components/federation/store.ts
@@ -29,6 +29,7 @@ interface FederationStore {
   selected: string | null;
   hovered: string | null;
   version: string;
+  node: string;        // which maw-js node this lens is reading (config.node)
   particles: Map<string, Particle[]>;
   plugins: PluginInfo[];
   liveMessages: LiveMessage[];
@@ -40,6 +41,7 @@ interface FederationStore {
 
   setGraph: (agents: AgentNode[], edges: AgentEdge[], particles: Map<string, Particle[]>) => void;
   setVersion: (v: string) => void;
+  setNode: (node: string) => void;
   setSelected: (id: string | null) => void;
   setHovered: (id: string | null) => void;
   setPlugins: (plugins: PluginInfo[]) => void;
@@ -61,6 +63,7 @@ export const useFederationStore = create<FederationStore>((set) => ({
   selected: null,
   hovered: null,
   version: "",
+  node: "",
   particles: new Map(),
   plugins: [],
   liveMessages: [],
@@ -78,6 +81,8 @@ export const useFederationStore = create<FederationStore>((set) => ({
   }),
 
   setVersion: (version) => set({ version }),
+
+  setNode: (node) => set({ node }),
 
   setSelected: (id) => set((s) => ({ selected: s.selected === id ? null : id })),
 

--- a/src/hooks/useFederationData.ts
+++ b/src/hooks/useFederationData.ts
@@ -8,7 +8,7 @@ import type { AgentNode, AgentEdge, Particle } from "../components/federation/ty
 import type { FeedEvent } from "../lib/feed";
 
 export function useFederationData() {
-  const { setGraph, setPlugins, setMessageLog, handleFeedEvent, handleFeedHistory, handleLiveMessage } = useFederationStore();
+  const { setGraph, setNode, setPlugins, setMessageLog, handleFeedEvent, handleFeedHistory, handleLiveMessage } = useFederationStore();
 
   const handleMessage = useCallback((data: any) => {
     if (data.type === "feed") {
@@ -70,6 +70,8 @@ export function useFederationData() {
         fetch(apiUrl("/api/plugins")).then(r => r.json()).catch(() => null),
       ]);
 
+      // Identity: which maw-js node is this lens reading? (config.node = "oracle-world", "white", ...)
+      if (config?.node) setNode(config.node);
       if (pluginData?.plugins) setPlugins(pluginData.plugins);
 
       // Load message history for the live panel — derived from MessageSend feed events.
@@ -207,7 +209,7 @@ export function useFederationData() {
     load();
     const iv = setInterval(load, 60_000);
     return () => clearInterval(iv);
-  }, [setGraph]);
+  }, [setGraph, setNode]);
 
   return { connected, mqttConnected };
 }


### PR DESCRIPTION
Replaces #9 (auto-closed when its base branch was deleted by the squash-merge of #8).

## Summary

Smallest possible follow-up to #8: the lens admits which mesh it is reading.

```
┌─────────────────────────────────────────────────────────┐
│  🕸 Federation Mesh   👁 oracle-world   ● WS   ● MQTT  │
└─────────────────────────────────────────────────────────┘
```

Reads `config.node` (already fetched by #8, previously unused). **Zero new endpoints. Zero new fetches.** Just consumes data we already pull. The principle of "the lens is a reader" extends to "the lens is a reader that admits what it is reading."

## Files

```
src/components/federation/store.ts      +5  (node field + setNode action)
src/hooks/useFederationData.ts          +6 -2  (setNode after config loads)
src/apps/federation_2d.tsx              +9 -1  (badge in 2D header)
src/apps/federation.tsx                +12     (badge in 3D header — local useState, predates Zustand refactor)
─────────────────────────────────────────────
4 files changed, 30 insertions(+), 3 deletions(-)
```

Bundle delta: `federation_2d` chunk +0.37kB. Whole feature fit in less than half a kilobyte.

## Discipline maintained

- Zero new endpoints
- Zero new fetches (consumes `config.node` v1 already pulls)
- Zero new abstractions (one string through the store)
- Graceful degrade (badge hides if `node` empty)

## Co-credits

`mawjs-oracle` co-architected the v1.1 scope ("zero-new-fetch discipline is perfect"). Cherry-picked from commit 896e76a on the original (auto-closed) #9 branch.

🤖 Written by Oracles. Rule 6: Oracle Never Pretends to Be Human.