### PR TITLE
chore(ci): add GitHub Actions build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,64 @@
+name: build
+
+# Lens CI: every PR and every push to main builds the lens and uploads
+# the dist artifact. The artifact is what `maw ui` (future, mawjs-oracle's
+# repo) will consume — same bytes from CI as you'd get from `npx vite build`
+# locally.
+#
+# Why this exists: PR #8 caught a "fresh clones cannot build" bug where
+# package.json declared `mqtt` but no lockfile pinned it. The build would
+# only work where someone had already run `npm install`. This workflow
+# guards against the same class of regression — if main cannot be built
+# from a fresh checkout, CI fails before merge.
+#
+# Pattern lesson: ground BEFORE shipping. CI is the automated form of
+# "ground before shipping" — the green check IS the curl. See
+# ψ/memory/feedback_ground_before_proposing.md (mawui-oracle vault).
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+# Cancel in-progress runs when a new commit lands on the same PR/branch.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: build (node 20)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build lens (vite)
+        run: npx vite build
+
+      - name: Show build output
+        run: |
+          echo "::group::dist tree"
+          find dist -type f -printf '%p  %s bytes\n' | sort
+          echo "::endgroup::"
+          echo "::group::dist size summary"
+          du -sh dist
+          du -sh dist/assets
+          echo "::endgroup::"
+
+      - name: Upload lens artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lens-dist
+          path: dist/
+          retention-days: 14
+          if-no-files-found: error


### PR DESCRIPTION
Replaces #10 (auto-closed when its base branch was deleted by the squash-merge of #8).

## Summary

First CI for `maw-ui`. Builds the lens on every PR and every push to `main`, uploads `dist/` as a 14-day artifact (`lens-dist`).

## Why

PR #8 caught a "fresh clones cannot build" bug: `package.json` declared `mqtt` but no lockfile pinned it. The build only worked where someone had already run `npm install`. CI ensures the **next** version of that bug never reaches main.

## Workflow shape

```yaml
on: pull_request + push to main
concurrency: cancel-in-progress on same ref
job: build (ubuntu-latest, node 20)
  - checkout
  - setup-node@v4 (npm cache)
  - npm ci                          # uses lockfile from #8
  - npx vite build
  - print dist tree + size summary
  - upload-artifact (dist/, 14d, error if empty)
```

64 lines total. No tests, no lint, no typecheck — those don't exist in the repo yet. Adding them in the same PR would be scope creep.

## "Match the command `maw ui`"

`maw ui` doesn't exist as a command yet. The artifact upload is the **bridge**: when mawjs-oracle adds a `maw ui` command, it can `gh run download lens-dist` to fetch the same bytes CI just produced. Same `dist/` from CI as `npx vite build` locally — single source of truth.

## Self-validation

The original CI run on the closed #10 was green in **22 seconds**, all 10 steps passed. This PR reuses the same yaml verbatim (cherry-picked from commit 659ba11).

## Co-credits

`mawjs-oracle` co-architected the night's "ground before shipping" rule that this CI now automates.

🤖 Written by Oracles. Rule 6: Oracle Never Pretends to Be Human.

Part of `collabs.lens-v1`. Three timepoints, one rule, fully automated:
`ground BEFORE proposing → ground BEFORE patching → CI BEFORE shipping`