### PR TITLE
fix(api): apiUrl honors explicit http://https:// in ?host= param

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,28 +1,63 @@
 /**
  * Centralized API host resolution — local.drizzle.studio pattern.
  *
- * When loaded from CF (local.buildwithoracle.com), user passes ?host=white.local:3456
- * Server auto-detects mkcert and serves HTTPS (same as drizzle-kit).
- * When loaded locally (same origin), uses relative paths.
+ * Loaded from CF (local.buildwithoracle.com): user passes ?host=white.local:3456
+ *   Server auto-detects mkcert and serves HTTPS (same as drizzle-kit).
+ * Loaded locally (same origin): uses relative paths.
+ *
+ * The host param accepts THREE forms:
+ *
+ *   ?host=white.local:3456              → https://white.local:3456
+ *                                         (bare host:port — defaults to https,
+ *                                         backwards-compatible behavior)
+ *
+ *   ?host=https://white.local:3456      → https://white.local:3456
+ *                                         (explicit https — same result)
+ *
+ *   ?host=http://oracle-world:3456      → http://oracle-world:3456
+ *                                         (explicit http — needed for plain-HTTP
+ *                                         maw-js nodes on the LAN, e.g. oracle-world
+ *                                         where mkcert isn't deployed)
+ *
+ * Discovered the http:// gap during /lens smoke testing on 2026-04-11:
+ * the v1.1 PR claimed "the lens reads any maw-js" but the apiUrl helper
+ * hardcoded https://, so any HTTP-only node was unreachable. This restores
+ * the claim. See ψ/memory/feedback_ground_before_proposing.md (claim drift —
+ * incident #5 in the night's count).
  */
 
 const params = new URLSearchParams(window.location.search);
-const hostParam = params.get("host"); // e.g. "white.local:3456"
+const hostParam = params.get("host");
 
 /** Whether we're running in remote mode */
 export const isRemote = !!hostParam;
 
+/** Resolved {protocol, host:port} from `hostParam`, or null if same-origin. */
+function resolveHost(): { httpProto: string; wsProto: string; host: string } | null {
+  if (!hostParam) return null;
+  if (hostParam.startsWith("https://")) {
+    return { httpProto: "https:", wsProto: "wss:", host: hostParam.slice("https://".length) };
+  }
+  if (hostParam.startsWith("http://")) {
+    return { httpProto: "http:", wsProto: "ws:", host: hostParam.slice("http://".length) };
+  }
+  // Bare host:port — default to https for backwards compatibility.
+  return { httpProto: "https:", wsProto: "wss:", host: hostParam };
+}
+
 /** Build full URL for fetch() calls */
 export function apiUrl(path: string): string {
-  if (!hostParam) return path;
-  return `https://${hostParam}${path}`;
+  const r = resolveHost();
+  if (!r) return path;
+  return `${r.httpProto}//${r.host}${path}`;
 }
 
 /** WebSocket URL */
 export function wsUrl(path: string): string {
-  if (!hostParam) {
+  const r = resolveHost();
+  if (!r) {
     const proto = location.protocol === "https:" ? "wss:" : "ws:";
     return `${proto}//${location.host}${path}`;
   }
-  return `wss://${hostParam}${path}`;
+  return `${r.wsProto}//${r.host}${path}`;
 }


### PR DESCRIPTION
## Summary

The v1.1 PR claimed *"the lens reads any maw-js"* but `src/lib/api.ts` hardcoded `https://${hostParam}`, so any plain-HTTP node (e.g. oracle-world on the LAN where mkcert isn't deployed) was unreachable. Half-grounded claim — caught by /lens smoke testing tonight.

This restores the claim. **Three accepted forms** for `?host=`:

| Form | Resolves to | Notes |
|---|---|---|
| `?host=white.local:3456` | `https://white.local:3456` | bare host:port — default (backwards compatible) |
| `?host=https://white.local:3456` | `https://white.local:3456` | explicit https |
| `?host=http://oracle-world:3456` | `http://oracle-world:3456` | **NEW** — explicit http for HTTP-only nodes |

WebSocket protocol auto-pairs: `http→ws`, `https→wss`.

## Diff

```
src/lib/api.ts  +43 / -8
```

The bulk of `+43` is documentation (the comment block at the top now explains all three forms). The actual logic change is small: a `resolveHost()` helper that splits `hostParam` into `{httpProto, wsProto, host}` so `apiUrl` and `wsUrl` share one source of truth for protocol selection.

## Backwards compatibility

✅ Existing CF / mkcert deploys (`?host=white.local:3456` style) keep their `https://` default. No callsites changed. No store changes.

## How I caught this

While creating the `/lens` skill (mawui-oracle vault, global), I smoke-tested the running vite dev server with `curl http://localhost:5173/api/config` and discovered:

1. The dev proxy (`vite.config.ts:44`) is hardcoded to white, so the default lens always shows white's mesh
2. The `?host=` query param can override that — but `api.ts` hardcodes `https://`, so any HTTP-only host fails

**Pattern lesson — incident #5 of the night** (will be filed in `feedback_ground_before_proposing.md` as "claim drift"): I wrote *"the lens reads any maw-js"* in the v1.1 PR description without testing the literal claim against an HTTP-only target. Same family as architecture/patch/schema drift — the rule fired again, this time at claim-time. The `/lens` skill turned out to be the test condition that caught it. Tools building tools building tools.

Per the night's pattern: this PR is small, focused, CI-guarded, and ships the smallest meaningful bridge between the v1.1 claim and reality.

## Test plan

- [x] `npx vite build` clean (TypeScript happy)
- [ ] CI green on this PR (will run on the workflow added in [#12](https://github.com/Soul-Brews-Studio/maw-ui/pull/12))
- [ ] Manual smoke: open `http://localhost:5173/federation_2d.html?host=http://oracle-world:3456` after merge — should now show `👁 oracle-world` in the header badge instead of failing on https handshake

🤖 Written by Oracles. Rule 6: Oracle Never Pretends to Be Human.

Part of the lens-v1.x line. Discovered by the `/lens` skill (mawui-oracle vault, global) during smoke testing.