### PR TITLE
ci: parallel build-self-hosted probe (non-blocking)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,3 +62,66 @@ jobs:
           path: dist/
           retention-days: 14
           if-no-files-found: error
+
+  # Parallel probe on the self-hosted runner (white.local).
+  # NON-BLOCKING: continue-on-error so a missing/offline runner cannot break
+  # main. The ubuntu-latest job above remains the merge gate. After this probe
+  # has been green for ~3 PRs, we can either:
+  #   (a) drop the ubuntu job and rely solely on self-hosted (faster, free
+  #       quota, can hit LAN resources for integration tests against real
+  #       maw-js endpoints)
+  #   (b) keep both for redundancy
+  #
+  # History note: maw-js had a `runs-on: self-hosted` workflow at one point
+  # (.github/workflows/inbox-auto-add.yml) which was disabled in commit
+  # 14f68f9 with the message "self-hosted runner offline, causing Discord
+  # spam." This probe exists explicitly to verify the runner is reliable
+  # before we trust it with required CI.
+  build-self-hosted:
+    name: build (self-hosted probe, non-blocking)
+    runs-on: self-hosted
+    continue-on-error: true
+    timeout-minutes: 10  # don't let an offline runner hang the workflow
+    steps:
+      - name: Runner info
+        run: |
+          echo "::group::runner environment"
+          echo "Hostname: $(hostname 2>/dev/null || echo unknown)"
+          echo "OS:       $(uname -a 2>/dev/null || echo unknown)"
+          echo "Whoami:   $(whoami 2>/dev/null || echo unknown)"
+          echo "PWD:      $(pwd)"
+          echo "PATH:     $PATH"
+          echo "Node:     $(node --version 2>/dev/null || echo 'not in PATH')"
+          echo "npm:      $(npm --version 2>/dev/null || echo 'not in PATH')"
+          echo "Git:      $(git --version 2>/dev/null || echo 'not installed')"
+          echo "::endgroup::"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build lens (vite)
+        run: npx vite build
+
+      - name: Show build output
+        run: |
+          echo "::group::dist size summary (self-hosted)"
+          du -sh dist
+          du -sh dist/assets
+          echo "::endgroup::"
+
+      - name: Upload lens artifact (self-hosted)
+        uses: actions/upload-artifact@v4
+        with:
+          name: lens-dist-self-hosted
+          path: dist/
+          retention-days: 7
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

Adds a **second, non-blocking job** to `build.yml` that runs the same `vite build` on the self-hosted runner (white.local). The existing `ubuntu-latest` job stays as the merge gate; the new probe just observes whether the self-hosted runner is alive and healthy.

```yaml
build:                # ← unchanged, ubuntu-latest, blocking (merge gate)
  runs-on: ubuntu-latest

build-self-hosted:    # ← NEW
  runs-on: self-hosted
  continue-on-error: true     # job failure does NOT fail workflow
  timeout-minutes: 10         # don't hang forever if runner is offline
```

## Why probed, not switched

`maw-js` had a `runs-on: self-hosted` workflow (`inbox-auto-add.yml`) which was **disabled in [14f68f9](https://github.com/Soul-Brews-Studio/maw-js/commit/14f68f9)** with the message:

> *"fix: disable inbox-auto-add workflow — self-hosted runner offline, causing Discord spam"*

Tonight Nat said *"white.local have gh actions self hosted!"* — which sounds like a fresh setup or a fix to that earlier offline issue. **But trust without verification is the rule firing.** Switching `runs-on: ubuntu-latest` → `runs-on: self-hosted` directly would mean: if the runner is still flaky, every future PR's CI hangs forever.

This probe is the **smallest grounded step** — verify reliability across ~3 real PR runs, then decide:

- (a) drop the ubuntu job, rely solely on self-hosted (faster, free quota, can hit LAN resources for integration tests against `oracle-world:3456` and `mba:3457`)
- (b) keep both for redundancy
- (c) document and stay on ubuntu if self-hosted isn't reliable yet

## Probe steps

1. **Runner info** — prints hostname, OS, whoami, PATH, node, npm, git versions. We need to *see* the runner to know what it can do. The disabled `inbox-auto-add.yml` exported `/usr/bin:/usr/local/bin:/opt/homebrew/bin:$PATH`, suggesting the runner is **macOS** (homebrew paths). This step confirms.
2. **Checkout, setup-node, npm ci, vite build** — same as the ubuntu job. The whole point is "does the same build pass on the same code on a different runner."
3. **Show build output** — `du -sh dist` so we can compare bundle sizes between runners (should be identical).
4. **Upload artifact** as `lens-dist-self-hosted` (distinct from the ubuntu job's `lens-dist` to avoid the upload-artifact@v4 name collision).

## What success looks like

After this PR merges, every subsequent PR will show **two checks**:
- ✅ `build (node 20)` (ubuntu-latest, required) ← merge gate
- ⚪ `build (self-hosted probe, non-blocking)` ← informational

If the second check is green for 3 PRs in a row, follow-up PR drops the ubuntu job. If it's red or hanging, follow-up PR removes the probe and we stay on ubuntu.

## Test plan

- [ ] CI runs on this PR (ubuntu job should pass; self-hosted job result is the data we want)
- [ ] **Look at the "Runner info" step output** to see what white's runner actually looks like (OS, paths, installed tools)
- [ ] If self-hosted job times out or errors, that's data — we know to fix the runner, not the workflow
- [ ] If self-hosted job passes, we have our first data point toward the ubuntu→self-hosted switchover

## Co-credits

mawjs-oracle's pattern of "ground BEFORE patching" applied to CI infrastructure tonight. Self-hosted-runner reliability is exactly the kind of thing where you want a probe before you switch your merge gate.

🤖 Written by Oracles. Rule 6: Oracle Never Pretends to Be Human.

Part of the lens-v1.x line — same arc as PR #8 → #11 → #12 → #13.