### PR TITLE
feat(vite): env-configurable backend URL via VITE_MAW_URL (cherry-pick of #6)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import { defineConfig } from "vite";
 import { resolve } from "path";
 import pkg from "./package.json";
 
+const MAW_HTTP = process.env.VITE_MAW_URL ?? "http://localhost:3456";
+const MAW_WS = MAW_HTTP.replace(/^http/, "ws");
+
 export default defineConfig({
   plugins: [tailwindcss(), react()],
   define: {
@@ -41,9 +44,9 @@ export default defineConfig({
     host: true,
     allowedHosts: true,
     proxy: {
-      "/api": "http://10.20.0.7:3456",
-      "/ws/pty": { target: "ws://10.20.0.7:3456", ws: true },
-      "/ws": { target: "ws://10.20.0.7:3456", ws: true },
+      "/api": MAW_HTTP,
+      "/ws/pty": { target: MAW_WS, ws: true },
+      "/ws": { target: MAW_WS, ws: true },
     },
   },
 });


### PR DESCRIPTION
## Summary

Cherry-picks the **env-var commit** from [#6](https://github.com/Soul-Brews-Studio/maw-ui/pull/6) (`luna/env-configurable-maw-url` branch by @TK7684) onto current `main`. Original work and credit go to **Luna Oracle** (`luna@oracle.dev`); this PR resolves the merge conflict and ships the value while preserving authorship.

## What it does

Makes the vite dev proxy backend URL **environment-configurable**:

```diff
+ const MAW_HTTP = process.env.VITE_MAW_URL ?? "http://localhost:3456";
+ const MAW_WS = MAW_HTTP.replace(/^http/, "ws");

  proxy: {
-   "/api": "http://10.20.0.7:3456",                  // hardcoded to white
-   "/ws/pty": { target: "ws://10.20.0.7:3456", ws: true },
-   "/ws": { target: "ws://10.20.0.7:3456", ws: true },
+   "/api": MAW_HTTP,                                  // env-configurable
+   "/ws/pty": { target: MAW_WS, ws: true },
+   "/ws": { target: MAW_WS, ws: true },
  },
```

Default is `http://localhost:3456` so each oracle's `npm run dev` proxies to **its own local** maw-js, not whichever node was hardcoded last. To override:

```bash
VITE_MAW_URL=http://10.20.0.7:3456 npm run dev   # point at white
VITE_MAW_URL=http://10.20.0.3:3457 npm run dev   # point at mba
```

WebSocket proxy URL is auto-derived (`http→ws`, `https→wss`).

## Why this complements PR #13 (the api.ts http:// fix)

Tonight's PR #13 made the **runtime** `?host=` query param accept `http://`, fixing the lens for browser-time routing. **This PR** fixes the **dev-proxy** layer so `npm run dev` defaults to localhost instead of a hardcoded peer. Together: **the lens runs anywhere, defaults to local, can target any peer at runtime.** That's the v1 mental model finally complete.

| Layer | Fix | PR |
|---|---|---|
| Runtime (`?host=` in URL) | http:// support | #13 ✅ |
| Dev proxy (`vite.config.ts`) | env-var, defaults to localhost | **THIS PR** |

## What I cherry-picked, what I didn't

PR #6 has two commits:

1. **`38e8ddc`** by Luna Oracle — `feat(vite): make backend URL env-configurable via VITE_MAW_URL` — **CHERRY-PICKED HERE** ✅
2. **`c664f95`** by Casa Oracle — `fix: WSL status detection + port migration to 3457` — **NOT cherry-picked** ❌

The second commit bundles a useful `useSessions.ts` "ready status for agents in recent message" fix with a port migration `3456 → 3457`. The port change would break our setup (white and oracle-world both run maw-js on `3456`; only mba and clinic-nat use `3457`). Unbundling that mixed-concern commit is bigger than tonight's scope. The useSessions.ts portion can land later as its own clean PR if anyone wants it.

## Conflict resolution

The conflict was on `vite.config.ts` `proxy` block:
- main had `"http://10.20.0.7:3456"` (hardcoded white IP)
- PR #6 wanted `MAW_HTTP` (env var)

Resolved in favor of `MAW_HTTP` (PR #6's intent). Also kept `allowedHosts: true` from main (more permissive than PR #6's `["white.local", "localhost", ...]` list).

## Test plan

- [x] `npx vite build` clean (ran locally pre-push)
- [ ] CI passes (workflow from #12 will run on this PR — first PR by a non-author to be guarded by it)
- [ ] After merge: `npm run dev` (no env var) → vite proxies `/api` to `localhost:3456` instead of `10.20.0.7:3456`
- [ ] After merge: `VITE_MAW_URL=http://10.20.0.7:3456 npm run dev` → vite proxies to white (matches old behavior)

## Co-credits

- **Luna Oracle** (`luna@oracle.dev`) — original author of commit `38e8ddc`, cherry-picked here
- **TK7684** — opened PR #6 with this work
- **mawui-oracle** (oracle-world hub, this account) — cherry-pick + conflict resolution + PR

After this lands, I'll comment on #6 to credit + explain the cherry-pick path. The original PR stays open for natman95's review.

🤖 Written by an Oracle. Rule 6: Oracle Never Pretends to Be Human.

Closes the v1 mental model loop. Part of the lens-v1.x line — same arc as #8 → #11 → #12 → #13 → #14.