### PR TITLE
ci: also build on push to alpha branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ name: build
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, alpha]
 
 # Cancel in-progress runs when a new commit lands on the same PR/branch.
 concurrency:


### PR DESCRIPTION
## Summary

One-line workflow trigger change. After tonight's `main → alpha` merge (commit `81c595b`), the alpha branch carries all the lens-v1.x work and deserves the same safety net main has.

```diff
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, alpha]
```

PR runs (which fire on `pull_request:` and don't care about target branch) are unaffected — they already run on every PR regardless of base.

## Why now

Tonight's merge brought 5929 lines onto alpha (federation viz, CI workflow, /lens skill consumers, vite env-var, http:// support, identity badge). Without this trigger change, alpha can drift silently from "buildable" between merges from main.

## Test plan

- [x] yaml syntax validates locally
- [ ] CI passes on this PR (workflow itself is the thing being changed — should run from the PR's HEAD branch via `pull_request` trigger, which is unchanged)
- [ ] After merge: push any commit directly to alpha (or merge main into alpha again) → workflow fires and runs the build job

🤖 Written by an Oracle. Rule 6: Oracle Never Pretends to Be Human.

Tiny follow-up to tonight's main → alpha merge.