### PR TITLE
feat(useSessions): /api/teams REST fallback + initial ready status from 'recent'

### DIFF
--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -37,6 +37,16 @@ export function useSessions() {
     });
   }, []);
 
+  // Fallback: fetch teams via REST on mount in case the WebSocket connection
+  // doesn't deliver them (race on first connect, server restart, etc.).
+  // Ported from c664f95 (Casa Oracle, PR #6).
+  useEffect(() => {
+    fetch("/api/teams")
+      .then(r => r.json())
+      .then(data => setTeams(data.teams || []))
+      .catch(() => {});
+  }, []);
+
   const markBusy = useFleetStore((s) => s.markBusy);
   const markSlept = useFleetStore((s) => s.markSlept);
   const clearSlept = useFleetStore((s) => s.clearSlept);
@@ -180,7 +190,23 @@ export function useSessions() {
       setSessions((data.sessions as Session[]).filter(s => !s.name.startsWith("maw-pty-")));
     } else if (data.type === "recent") {
       const agents: { target: string; name: string; session: string }[] = data.agents || [];
-      if (agents.length > 0) markBusy(agents);
+      if (agents.length > 0) {
+        markBusy(agents);
+        // Set initial "ready" status for agents detected as running Claude.
+        // They may not have fired feed events yet — without this they'd render
+        // as "idle" for up to BUSY_TIMEOUT seconds before the first feed event
+        // bumps them to "ready". Only upgrade idle/missing — never downgrade
+        // from busy/crashed.
+        // Ported from c664f95 (Casa Oracle, PR #6) into the current
+        // useFeedStatusStore architecture.
+        const store = useFeedStatusStore.getState();
+        for (const a of agents) {
+          const current = store.statuses[a.target];
+          if (!current || current === "idle") {
+            store.setStatus(a.target, "ready");
+          }
+        }
+      }
     } else if (data.type === "feed") {
       const feedEvent = data.event as FeedEvent;
       setFeedEvents(prev => {


### PR DESCRIPTION
## Summary

Closes the remaining value from [#6](https://github.com/Soul-Brews-Studio/maw-ui/pull/6) by **porting the intent** of Casa Oracle's `c664f95` commit into the current `useFeedStatusStore` architecture.

Two small UX fixes (+27/-1 in `src/hooks/useSessions.ts`):

### 1. Teams REST fallback

```typescript
useEffect(() => {
  fetch("/api/teams")
    .then(r => r.json())
    .then(data => setTeams(data.teams || []))
    .catch(() => {});
}, []);
```

Defensive fetch on mount in case the WebSocket doesn't deliver teams (race on first connect, server restart, etc.). Pure additive — no callsite changes.

### 2. Initial "ready" status from `recent` message

When the WebSocket sends a `recent` message listing detected Claude sessions, those agents currently render as `idle` for up to `BUSY_TIMEOUT` (15s) before the first feed event bumps them to `ready`. This pre-marks them via `useFeedStatusStore.setStatus(target, "ready")` so the UI reflects reality immediately:

```typescript
const store = useFeedStatusStore.getState();
for (const a of agents) {
  const current = store.statuses[a.target];
  if (!current || current === "idle") {
    store.setStatus(a.target, "ready");
  }
}
```

**Only upgrades `idle/missing` — never downgrades from `busy/crashed`.** Safe.

## Why "ported" not "cherry-picked"

The `c664f95` diff was written against an older version of `useSessions.ts` with local `setCaptureData` state and a `captureData[target] = { preview, status }` shape. After tonight's earlier refactors and the broader Zustand migration, that local state is gone — `useSessions.ts` now uses three separate stores (`useFleetStore`, `useFeedStatusStore`, `usePreviewStore`).

The **intent** translates cleanly: `setStatus(target, "ready")` via `useFeedStatusStore`. The **literal patch** wouldn't apply. So this is a re-implementation faithful to the original spirit, with `Co-Authored-By: Casa Oracle` to preserve credit.

## What I deliberately did NOT port

`c664f95` ALSO modified `vite.config.ts` to migrate proxy targets from `white.local:3456` to `localhost:3457` (port + host change). That would break our setup — white and oracle-world both run maw-js on `3456`; only mba and clinic-nat are on `3457`. The env-var version of `vite.config.ts` is already on main via [PR #15](https://github.com/Soul-Brews-Studio/maw-ui/pull/15) (Luna Oracle's `38e8ddc` cherry-pick), which is the version we want.

## PR #6 status after this lands

| PR #6 commit | What it did | Status |
|---|---|---|
| `38e8ddc` (Luna) | env-var `VITE_MAW_URL` | ✅ on main via #15 |
| `c664f95` (Casa) — useSessions.ts | ready status + teams fetch | ✅ on main via THIS PR (ported) |
| `c664f95` (Casa) — vite.config.ts | port migration to 3457 | ❌ deliberately NOT ported (would break setup; superseded by #15's env var) |

After this merges, **PR #6 has zero remaining value** and can be closed as fully superseded. I'll comment on #6 with this status when this PR lands.

## Test plan

- [x] `npx vite build` clean (TypeScript happy)
- [ ] CI passes (workflow from #12 will run on this PR)
- [ ] After merge: open the dashboard against a maw-js with running Claude sessions → those agents should render as "ready" immediately, not idle-then-ready

## Co-credits

- **Casa Oracle** (`casa@luna-os.dev`) — original intent in `c664f95`
- **Luna Oracle** + **TK7684** — opened PR #6 carrying the work
- **mawui-oracle** (oracle-world) — port + commit + PR

🤖 Written by an Oracle. Rule 6: Oracle Never Pretends to Be Human.

Closes the v1.x lens arc on the maw-ui side. Same arc as #8 → #11 → #12 → #13 → #14 → #2 → #15 → #16.