### PR TITLE
fix(apiUrl): sweep remaining relative fetches in non-lens views

### DIFF
--- a/src/apps/party.tsx
+++ b/src/apps/party.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import "../index.css";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { apiUrl } from "../lib/api";
 import { stripAnsi } from "../lib/ansi";
 import type { FeedEvent } from "../lib/feed";
 
@@ -35,7 +36,7 @@ function useFederation() {
   const [error, setError] = useState("");
 
   const refresh = useCallback(() => {
-    fetch("/api/federation/status")
+    fetch(apiUrl("/api/federation/status"))
       .then(r => r.json())
       .then(setStatus)
       .catch(e => setError(e.message));
@@ -326,7 +327,7 @@ function JoinCard({ onRefresh }: { onRefresh: () => void }) {
     setJoining(true);
     setResult("");
     try {
-      const res = await fetch("/api/ping", {
+      const res = await fetch(apiUrl("/api/ping"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ url: url.trim() }),

--- a/src/apps/v2.tsx
+++ b/src/apps/v2.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { useState, useEffect, useCallback, useRef } from "react";
 import "../index.css";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { apiUrl } from "../lib/api";
 import { stripAnsi } from "../lib/ansi";
 import type { FeedEvent } from "../lib/feed";
 
@@ -54,8 +55,8 @@ function App() {
 
   // Fetch sessions on mount (WS sends them periodically, not immediately)
   useEffect(() => {
-    fetch("/api/sessions").then(r => r.json()).then(setSessions).catch(() => {});
-    fetch("/api/worktrees").then(r => r.json()).then(d => setTeams(d.teams || [])).catch(() => {});
+    fetch(apiUrl("/api/sessions")).then(r => r.json()).then(setSessions).catch(() => {});
+    fetch(apiUrl("/api/worktrees")).then(r => r.json()).then(d => setTeams(d.teams || [])).catch(() => {});
   }, []);
 
   // Derive agents

--- a/src/apps/workspace.tsx
+++ b/src/apps/workspace.tsx
@@ -2,6 +2,7 @@ import { createRoot } from "react-dom/client";
 import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import "../index.css";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { apiUrl } from "../lib/api";
 import type { FeedEvent, FeedEventType } from "../lib/feed";
 import type { PaneStatus, Session } from "../lib/types";
 
@@ -202,7 +203,7 @@ function App() {
       ? [null, sendTarget]
       : sendTarget.split("/");
 
-    fetch("/api/action", {
+    fetch(apiUrl("/api/action"), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ type: "send", target: agent || sendTarget, text: sendText.trim() + "\r" }),
@@ -445,7 +446,7 @@ function JoinWorkspace() {
           onClick={() => {
             if (!name.trim()) return;
             setCreating(true);
-            fetch("/api/action", {
+            fetch(apiUrl("/api/action"), {
               method: "POST",
               headers: { "Content-Type": "application/json" },
               body: JSON.stringify({ type: "workspace-create", name: name.trim() }),

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback, useRef, useEffect, useMemo } from "react";
 import type { Session, AgentState, AgentEvent } from "../lib/types";
 import type { Team } from "../components/TeamPanel";
+import { apiUrl } from "../lib/api";
 import { stripAnsi } from "../lib/ansi";
 import { agentSortKey } from "../lib/constants";
 import { playWakeSound } from "../lib/sounds";
@@ -41,7 +42,7 @@ export function useSessions() {
   // doesn't deliver them (race on first connect, server restart, etc.).
   // Ported from c664f95 (Casa Oracle, PR #6).
   useEffect(() => {
-    fetch("/api/teams")
+    fetch(apiUrl("/api/teams"))
       .then(r => r.json())
       .then(data => setTeams(data.teams || []))
       .catch(() => {});


### PR DESCRIPTION
## Summary

Complete the `apiUrl()` runtime `?host=` coverage that was started in [`src/lib/api.ts`](https://github.com/Soul-Brews-Studio/maw-ui/blob/main/src/lib/api.ts). The federation lens already uses `apiUrl()` on its 4 v1 endpoints (via `useFederationData.ts`), but 7 fetch calls in non-lens views still used raw relative paths — breaking `?host=` for those views.

## The gap

| File | Line | Before | After |
|---|---|---|---|
| `src/apps/v2.tsx` | 57 | `fetch("/api/sessions")` | `fetch(apiUrl("/api/sessions"))` |
| `src/apps/v2.tsx` | 58 | `fetch("/api/worktrees")` | `fetch(apiUrl("/api/worktrees"))` |
| `src/apps/workspace.tsx` | 205 | `fetch("/api/action", ...)` | `fetch(apiUrl("/api/action"), ...)` |
| `src/apps/workspace.tsx` | 448 | `fetch("/api/action", ...)` | `fetch(apiUrl("/api/action"), ...)` |
| `src/hooks/useSessions.ts` | 44 | `fetch("/api/teams")` | `fetch(apiUrl("/api/teams"))` |
| `src/apps/party.tsx` | 38 | `fetch("/api/federation/status")` | `fetch(apiUrl("/api/federation/status"))` |
| `src/apps/party.tsx` | 329 | `fetch("/api/ping", ...)` | `fetch(apiUrl("/api/ping"), ...)` |

All 7 swapped to `fetch(apiUrl("/api/..."))`. Behavior is **unchanged when `?host=` is absent** (`apiUrl()` returns the path as-is for same-origin). When `?host=` is set, these views now correctly route to the remote backend — matching the lens pattern.

## Why this is "pure completion, not new feature work"

- `src/lib/api.ts` already implements the full `?host=` runtime resolver (drizzle-studio pattern) with 3 URL forms (bare `host:port`, `http://`, `https://`), and was shipped in a prior PR by mawui-oracle
- `useFederationData.ts` already uses `apiUrl()` on all 4 v1 endpoints (`/api/config`, `/api/fleet-config`, `/api/feed`, `/api/plugins`)
- `useWebSocket.ts` already uses `wsUrl()`
- `src/server.ts:40` on maw-js already has `app.use("/api/*", cors())` — the backend half is done
- This PR is the **last mechanical step** to make every maw-ui page respect `?host=`, not just the federation lens

## Grounding caught two near-misses before this PR was written

**Near-miss 1**: I almost drafted a duplicate `src/lib/host.ts`. Reading `src/lib/api.ts` first revealed the pattern was already shipped — including the `http://` gap fix from the v1.1 `/lens` smoke-test incident cited in the file's header comment. Had I skipped reading, the PR would have been a duplicate of existing mawui work.

**Near-miss 2**: An earlier research trace (`mawjs-oracle/ψ/memory/traces/2026-04-11/2230_global-maw-ui-host-param-proof.md`) claimed "maw-js has ZERO CORS middleware" and scoped Phase 2 of the ship around adding it. WRONG: `src/server.ts:40` already has the hono/cors middleware. The earlier grep was scoped too narrowly to `src/api/` and missed the `server.ts` mount. The 2230 trace will be updated with the correction.

Both near-misses were caught by the **"ground before proposing"** rule from [`mawui-oracle/ψ/memory/feedback_ground_before_proposing.md`](https://github.com/Soul-Brews-Studio/maw-ui) — fourth grounding-catch this session alone.

## Test plan

- [x] `bun run build` — clean (no new warnings beyond pre-existing chunk-size)
- [ ] Manual smoke test: load `v2`, `workspace`, `party` views with and without `?host=http://oracle-world:3456`
- [ ] Verify same-origin default is preserved (no `?host=` → relative fetches still work)
- [ ] `gh pr checks` — wait for CI (maw-ui has CI per #12)

## Coordination note for @mawui

This is in your territory (`src/lib/api.ts` authorship) so I'm filing as **DRAFT** and not merging. You + Nat hold the merge nod. Happy to rebase/adjust if you want a different shape.

Related siblings shipping tonight at `mawjs-oracle/.claude/skills/{wormhole,warp}/SKILL.md` — the knowledge-layer federation primitives that run on the same philosophical axis as this UI-layer `?host=` pattern: viewer global, data sovereign.

🤖 ตอบโดย mawjs จาก [Nat] → mawjs-oracle