### PR TITLE
draft: federation-join-easy maw-ui helpers — WormholeClient + PeerProxy + peerConnection + banner

### DIFF
--- a/src/lib/peerConnection.test.ts
+++ b/src/lib/peerConnection.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for resolvePeerConnection + canFetchDirectly — iteration 5.
+ *
+ * These tests lock the mixed-content-rule classification and the four-kind
+ * discriminated union shape. The load-bearing invariant is that
+ * `mixed-content-blocked` is surfaced as a dedicated kind, NOT hidden as
+ * "direct that will fail at fetch time" — so callers can show a clear
+ * error instead of a mysterious fetch failure.
+ */
+
+import { describe, test, expect } from "bun:test";
+import { resolvePeerConnection, canFetchDirectly } from "./peerConnection";
+
+describe("resolvePeerConnection — same-origin path", () => {
+  test("null → same-origin", () => {
+    const pc = resolvePeerConnection(null);
+    expect(pc.kind).toBe("same-origin");
+  });
+
+  test("undefined → same-origin", () => {
+    const pc = resolvePeerConnection(undefined);
+    expect(pc.kind).toBe("same-origin");
+  });
+
+  test("empty string → same-origin", () => {
+    const pc = resolvePeerConnection("");
+    expect(pc.kind).toBe("same-origin");
+  });
+
+  test("whitespace-only → same-origin", () => {
+    const pc = resolvePeerConnection("   ");
+    expect(pc.kind).toBe("same-origin");
+  });
+});
+
+describe("resolvePeerConnection — direct path", () => {
+  test("explicit https:// URL → direct https from any origin", () => {
+    const pc = resolvePeerConnection("https://white.local:3456", "https:");
+    expect(pc).toEqual({
+      kind: "direct",
+      protocol: "https",
+      baseUrl: "https://white.local:3456",
+    });
+  });
+
+  test("explicit https:// URL → direct from http origin too", () => {
+    const pc = resolvePeerConnection("https://white.local:3456", "http:");
+    expect(pc.kind).toBe("direct");
+    if (pc.kind === "direct") expect(pc.protocol).toBe("https");
+  });
+
+  test("explicit http:// URL from http origin → direct http", () => {
+    const pc = resolvePeerConnection("http://10.20.0.7:3456", "http:");
+    expect(pc).toEqual({
+      kind: "direct",
+      protocol: "http",
+      baseUrl: "http://10.20.0.7:3456",
+    });
+  });
+
+  test("bare host:port defaults to https → direct", () => {
+    const pc = resolvePeerConnection("white.local:3456", "https:");
+    expect(pc).toEqual({
+      kind: "direct",
+      protocol: "https",
+      baseUrl: "https://white.local:3456",
+    });
+  });
+
+  test("bare hostname without port → direct https", () => {
+    const pc = resolvePeerConnection("oracle-world", "https:");
+    expect(pc.kind).toBe("direct");
+    if (pc.kind === "direct") {
+      expect(pc.protocol).toBe("https");
+      expect(pc.baseUrl).toBe("https://oracle-world");
+    }
+  });
+});
+
+describe("resolvePeerConnection — mixed-content-blocked path (load-bearing)", () => {
+  test("https origin + http peer → mixed-content-blocked", () => {
+    const pc = resolvePeerConnection("http://10.20.0.7:3456", "https:");
+    expect(pc.kind).toBe("mixed-content-blocked");
+    if (pc.kind === "mixed-content-blocked") {
+      expect(pc.peerUrl).toBe("http://10.20.0.7:3456");
+      expect(pc.hint).toContain("mixed-content");
+      expect(pc.hint).toContain("maw ui --from-ci");
+      expect(pc.hint).toContain("/api/proxy/*");
+      expect(pc.hint).toContain("/wormhole");
+    }
+  });
+
+  test("https origin + http hostname (no port) → mixed-content-blocked", () => {
+    const pc = resolvePeerConnection("http://oracle-world.laris.co", "https:");
+    expect(pc.kind).toBe("mixed-content-blocked");
+  });
+
+  test("bare host:port does NOT trigger mixed-content (defaults to https)", () => {
+    // Even from an HTTPS origin, a bare host:port is treated as https by
+    // resolveHost() in src/lib/api.ts, matching the existing pattern.
+    const pc = resolvePeerConnection("10.20.0.7:3456", "https:");
+    expect(pc.kind).toBe("direct");
+  });
+
+  test("http origin + http peer is NOT blocked", () => {
+    const pc = resolvePeerConnection("http://10.20.0.7:3456", "http:");
+    expect(pc.kind).toBe("direct");
+  });
+
+  test("http origin + https peer is NOT blocked", () => {
+    const pc = resolvePeerConnection("https://white.local:3456", "http:");
+    expect(pc.kind).toBe("direct");
+  });
+});
+
+describe("resolvePeerConnection — invalid path", () => {
+  test("garbage input → invalid", () => {
+    const pc = resolvePeerConnection("not a valid host!!!", "https:");
+    expect(pc.kind).toBe("invalid");
+    if (pc.kind === "invalid") {
+      expect(pc.input).toBe("not a valid host!!!");
+      expect(pc.reason).toContain("unrecognized");
+    }
+  });
+
+  test("leading colon → invalid", () => {
+    const pc = resolvePeerConnection(":3456", "https:");
+    expect(pc.kind).toBe("invalid");
+  });
+
+  test("unknown protocol → invalid", () => {
+    const pc = resolvePeerConnection("ftp://example.com", "https:");
+    expect(pc.kind).toBe("invalid");
+  });
+
+  test("spaces in hostname → invalid", () => {
+    const pc = resolvePeerConnection("foo bar.com", "https:");
+    expect(pc.kind).toBe("invalid");
+  });
+});
+
+describe("resolvePeerConnection — default origin detection", () => {
+  test("when location is undefined, defaults to https (conservative)", () => {
+    // In bun test, `location` is undefined — so the default should kick in.
+    // HTTPS default means HTTP peers will be classified as mixed-content-blocked,
+    // which is the correct conservative behavior (surfaces the problem).
+    const pc = resolvePeerConnection("http://10.20.0.7:3456");
+    expect(pc.kind).toBe("mixed-content-blocked");
+  });
+
+  test("explicit http origin override works even without location", () => {
+    const pc = resolvePeerConnection("http://10.20.0.7:3456", "http:");
+    expect(pc.kind).toBe("direct");
+  });
+});
+
+describe("canFetchDirectly — convenience helper", () => {
+  test("returns true for same-origin", () => {
+    expect(canFetchDirectly(null)).toBe(true);
+    expect(canFetchDirectly("")).toBe(true);
+  });
+
+  test("returns true for direct", () => {
+    expect(canFetchDirectly("https://white.local:3456", "https:")).toBe(true);
+    expect(canFetchDirectly("http://10.20.0.7:3456", "http:")).toBe(true);
+  });
+
+  test("returns false for mixed-content-blocked", () => {
+    expect(canFetchDirectly("http://10.20.0.7:3456", "https:")).toBe(false);
+  });
+
+  test("returns false for invalid input", () => {
+    expect(canFetchDirectly("garbage!!!", "https:")).toBe(false);
+  });
+});
+
+describe("the four-kind invariant", () => {
+  test("every resolvePeerConnection result matches one of the four kinds", () => {
+    // Lock the discriminated union surface so adding a new kind forces a
+    // deliberate update here.
+    const samples = [
+      null,
+      "",
+      "https://foo:3456",
+      "http://foo:3456",
+      "foo:3456",
+      "garbage!!!",
+    ];
+    const seen = new Set<string>();
+    for (const s of samples) {
+      const pc = resolvePeerConnection(s, "https:");
+      seen.add(pc.kind);
+      expect(["same-origin", "direct", "mixed-content-blocked", "invalid"]).toContain(
+        pc.kind,
+      );
+    }
+    // All four kinds are reachable from this sample set (if the code ever
+    // stops returning one, this test catches it).
+    expect(seen.size).toBe(4);
+  });
+});

--- a/src/lib/peerConnection.ts
+++ b/src/lib/peerConnection.ts
@@ -1,0 +1,232 @@
+/**
+ * resolvePeerConnection — classify how a caller can reach a peer via the
+ * browser's fetch primitive, given the `?host=` form and the current origin.
+ *
+ * PROTOTYPE — iteration 5 of the federation-join-easy /loop. Drafted on the
+ * feat/wormhole-client-draft branch. See
+ * mawui-oracle/ψ/writing/federation-join-easy.md for the full context and
+ * the iteration-5 architectural refinement.
+ *
+ * ## The shape confusion this helper closes
+ *
+ * Iterations 1-4 framed a "runtime dispatcher" that would pick between
+ * `apiUrl()` (direct fetch) and `WormholeClient` (relay) based on peer shape.
+ * **That framing was wrong** — the two primitives serve DIFFERENT needs:
+ *
+ *   - `apiUrl()` is for **REST data fetching** — `/api/config`, `/api/feed`,
+ *     `/api/sessions`, etc. Arbitrary HTTP GET/POST against a peer's API.
+ *   - `WormholeClient` is for **signed command execution** — `/dig`,
+ *     `/trace`, `/recap`. RPC-shaped, readonly-or-allowlisted, returns a
+ *     command output string.
+ *
+ * The wormhole protocol does NOT generalize to arbitrary REST relay —
+ * that would require a different endpoint shape (`POST /api/proxy/...`
+ * wrapping an HTTP request/response). Conflating them was an error caught
+ * in iteration 5 grounding.
+ *
+ * ## What this helper actually does
+ *
+ * It classifies a `?host=` value into one of four `PeerConnection` kinds
+ * and hands the caller back enough information to do the right thing OR
+ * show a clear error. It does NOT wrap `fetch`. It does NOT hide failure
+ * modes. The mixed-content-blocked case is surfaced as a dedicated kind,
+ * not silently broken.
+ *
+ * ## Mixed-content rule (the real browser-side blocker)
+ *
+ * `src/server.ts:40` in maw-js already has permissive CORS + Private
+ * Network Access header. CORS is NOT the blocker for direct browser →
+ * LAN-peer fetches. The real blocker is the browser's mixed-content rule:
+ *
+ *   origin = https://...   →   peer = http://...   →   BLOCKED (active content)
+ *   origin = http://...    →   peer = http://...   →   OK
+ *   origin = https://...   →   peer = https://...  →   OK
+ *   origin = http://...    →   peer = https://...  →   OK (mixed OK upgraded)
+ *
+ * When mixed-content blocks a direct fetch, the caller has three options:
+ *
+ *   1. **Run maw-ui locally** (the "pro path") — serve the lens from
+ *      http://localhost:5173 or via `maw ui --from-ci`. Same-origin
+ *      fetches work natively, no wormhole needed.
+ *   2. **Use a future `POST /api/proxy/*` endpoint** — not yet built.
+ *      This is iteration 5+ scope. It would be a generic HTTP proxy
+ *      through the local backend for arbitrary REST calls to HTTP-LAN
+ *      peers.
+ *   3. **Use `/wormhole`** — but only for command execution, not for
+ *      REST fetches. If the caller wants `/dig` output, wormhole works;
+ *      if they want `/api/sessions`, wormhole doesn't help.
+ *
+ * This helper surfaces option 1 + 2 + 3 as an explicit error with a hint.
+ * It does NOT paper over the limitation.
+ */
+
+// ---- Types ---------------------------------------------------------------
+
+export type PeerConnection =
+  | {
+      /**
+       * No `?host=` param — fetch against the same origin that served the
+       * HTML. `apiUrl(path)` returns the path as-is.
+       */
+      kind: "same-origin";
+    }
+  | {
+      /**
+       * Cross-origin fetch is possible — either HTTPS peer from any origin,
+       * HTTP peer from HTTP origin, or bare `host:port` (defaults to HTTPS).
+       * `apiUrl(path)` returns the absolute URL; `fetch()` succeeds.
+       */
+      kind: "direct";
+      protocol: "http" | "https";
+      baseUrl: string;
+    }
+  | {
+      /**
+       * HTTPS origin trying to reach an HTTP peer — browser blocks via
+       * mixed-content rule. Caller MUST use one of:
+       *   - Run maw-ui locally (same-origin to a local backend)
+       *   - Future `POST /api/proxy/*` endpoint (not yet built)
+       *   - `/wormhole` for command execution (NOT for REST reads)
+       */
+      kind: "mixed-content-blocked";
+      peerUrl: string;
+      hint: string;
+    }
+  | {
+      /**
+       * The `?host=` value could not be parsed as any known shape.
+       */
+      kind: "invalid";
+      reason: string;
+      input: string;
+    };
+
+// ---- Helpers -------------------------------------------------------------
+
+/**
+ * Detect the current page's protocol. Defaults to "https:" in test/SSR
+ * environments where `location` is undefined — the conservative default
+ * because it produces more mixed-content-blocked classifications, which
+ * surfaces the real-world problem rather than hiding it.
+ */
+function currentProtocol(): "http:" | "https:" {
+  if (typeof location === "undefined") return "https:";
+  return location.protocol === "http:" ? "http:" : "https:";
+}
+
+/**
+ * Parse a `?host=` value into its protocol + host parts. Accepts three
+ * forms (matching `src/lib/api.ts:resolveHost` semantics):
+ *
+ *   - Bare `host:port` — defaults to https
+ *   - Full `http://host[:port]`
+ *   - Full `https://host[:port]`
+ *
+ * Returns null if the input is malformed.
+ */
+function parseHostParam(
+  hostParam: string,
+): { protocol: "http" | "https"; host: string } | null {
+  const trimmed = hostParam.trim();
+  if (!trimmed) return null;
+
+  if (trimmed.startsWith("https://")) {
+    return { protocol: "https", host: trimmed.slice("https://".length) };
+  }
+  if (trimmed.startsWith("http://")) {
+    return { protocol: "http", host: trimmed.slice("http://".length) };
+  }
+
+  // Bare form — must look like `host[:port]`, defaults to https
+  // Accept hostnames with letters, digits, dots, dashes, and an optional :port
+  if (/^[a-zA-Z0-9][a-zA-Z0-9.\-]*(?::\d+)?$/.test(trimmed)) {
+    return { protocol: "https", host: trimmed };
+  }
+
+  return null;
+}
+
+// ---- Main helper ---------------------------------------------------------
+
+/**
+ * Classify how a caller can reach a peer. Given a `?host=` value (typically
+ * `new URLSearchParams(location.search).get("host")`) and an optional
+ * explicit origin protocol (for testing / SSR), return a discriminated
+ * union describing the connection shape.
+ *
+ * Callers match on `.kind` and do the right thing:
+ *
+ *   const pc = resolvePeerConnection(new URLSearchParams(location.search).get("host"));
+ *   switch (pc.kind) {
+ *     case "same-origin":
+ *     case "direct":
+ *       // Use apiUrl() + fetch — works
+ *       break;
+ *     case "mixed-content-blocked":
+ *       // Show error banner: "HTTPS origin can't reach HTTP peer directly"
+ *       // Offer: run locally, wait for proxy endpoint, or use /wormhole for cmds
+ *       break;
+ *     case "invalid":
+ *       // Show error: malformed ?host= value
+ *       break;
+ *   }
+ */
+export function resolvePeerConnection(
+  hostParam: string | null | undefined,
+  originProtocol: "http:" | "https:" = currentProtocol(),
+): PeerConnection {
+  if (!hostParam || hostParam.trim() === "") {
+    return { kind: "same-origin" };
+  }
+
+  const parsed = parseHostParam(hostParam);
+  if (!parsed) {
+    return {
+      kind: "invalid",
+      reason: "unrecognized host shape — expected `host:port`, `http://...`, or `https://...`",
+      input: hostParam,
+    };
+  }
+
+  const peerUrl = `${parsed.protocol}://${parsed.host}`;
+
+  // Mixed-content rule: HTTPS origin trying to reach HTTP peer is blocked
+  // by every modern browser. Active-content mixed requests are NEVER
+  // auto-upgraded; the fetch will fail with an opaque error.
+  if (originProtocol === "https:" && parsed.protocol === "http") {
+    return {
+      kind: "mixed-content-blocked",
+      peerUrl,
+      hint:
+        "Browser mixed-content rule blocks HTTPS → HTTP fetches. " +
+        "Options: (a) run `maw ui --from-ci` locally and use same-origin; " +
+        "(b) wait for POST /api/proxy/* generic relay endpoint (iteration 5+); " +
+        "(c) use /wormhole for signed COMMAND execution (not REST reads).",
+    };
+  }
+
+  return {
+    kind: "direct",
+    protocol: parsed.protocol,
+    baseUrl: peerUrl,
+  };
+}
+
+// ---- Convenience helpers -------------------------------------------------
+
+/**
+ * Shortcut: can the browser fetch REST data from this peer directly?
+ * Returns `true` for `same-origin` and `direct`; `false` for
+ * `mixed-content-blocked` and `invalid`.
+ *
+ * Useful for gating UI elements that depend on arbitrary REST reads.
+ * For command execution, use `WormholeClient` instead regardless of
+ * this helper's result.
+ */
+export function canFetchDirectly(
+  hostParam: string | null | undefined,
+  originProtocol?: "http:" | "https:",
+): boolean {
+  const pc = resolvePeerConnection(hostParam, originProtocol);
+  return pc.kind === "same-origin" || pc.kind === "direct";
+}

--- a/src/lib/peerConnectionBanner.test.ts
+++ b/src/lib/peerConnectionBanner.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Tests for peerConnectionBanner — pure helper that derives banner content
+ * from a PeerConnection classification.
+ *
+ * PROTOTYPE — iteration 8 of the federation-join-easy /loop. See
+ * mawui-oracle/ψ/writing/federation-join-easy.md for context.
+ *
+ * Tests are pure — no React, no DOM, no rendering. The component layer
+ * (a 5-line wrapper) is deferred until a real call site needs it.
+ */
+
+import { describe, test, expect } from "bun:test";
+import {
+  getPeerConnectionBanner,
+  shouldShowBanner,
+  bannerSeverity,
+} from "./peerConnectionBanner";
+import type { PeerConnection } from "./peerConnection";
+
+// ---- Fixtures ------------------------------------------------------------
+
+const sameOrigin: PeerConnection = { kind: "same-origin" };
+
+const direct: PeerConnection = {
+  kind: "direct",
+  protocol: "https",
+  baseUrl: "https://white.local:3456",
+};
+
+const mixedContentBlocked: PeerConnection = {
+  kind: "mixed-content-blocked",
+  peerUrl: "http://10.20.0.7:3456",
+  hint: "Browser mixed-content rule blocks HTTPS → HTTP fetches.",
+};
+
+const invalid: PeerConnection = {
+  kind: "invalid",
+  reason: "unrecognized host shape",
+  input: "garbage!!!",
+};
+
+// ---- getPeerConnectionBanner — happy-path returns null ------------------
+
+describe("getPeerConnectionBanner — happy paths return null", () => {
+  test("same-origin → null", () => {
+    expect(getPeerConnectionBanner(sameOrigin)).toBeNull();
+  });
+
+  test("direct → null", () => {
+    expect(getPeerConnectionBanner(direct)).toBeNull();
+  });
+});
+
+// ---- getPeerConnectionBanner — mixed-content-blocked --------------------
+
+describe("getPeerConnectionBanner — mixed-content-blocked", () => {
+  test("returns error severity", () => {
+    const banner = getPeerConnectionBanner(mixedContentBlocked);
+    expect(banner).not.toBeNull();
+    expect(banner!.severity).toBe("error");
+  });
+
+  test("title names the problem clearly (no jargon)", () => {
+    const banner = getPeerConnectionBanner(mixedContentBlocked)!;
+    expect(banner.title.toLowerCase()).toContain("cannot reach");
+  });
+
+  test("message includes the actual peer URL", () => {
+    const banner = getPeerConnectionBanner(mixedContentBlocked)!;
+    expect(banner.message).toContain("http://10.20.0.7:3456");
+  });
+
+  test("message explicitly says it's NOT a CORS issue", () => {
+    // Load-bearing: users will think CORS first. The banner must rule
+    // it out so they don't waste time chasing the wrong fix.
+    const banner = getPeerConnectionBanner(mixedContentBlocked)!;
+    const lower = banner.message.toLowerCase();
+    expect(lower).toContain("cors");
+    // Accept "isn't a cors", "is not a cors", "not a cors" — any negation form.
+    const negatesCors =
+      lower.includes("isn't a cors") ||
+      lower.includes("is not a cors") ||
+      lower.includes("not a cors");
+    expect(negatesCors).toBe(true);
+  });
+
+  test("provides three concrete actions", () => {
+    const banner = getPeerConnectionBanner(mixedContentBlocked)!;
+    expect(banner.actions.length).toBe(3);
+  });
+
+  test("actions cover: run locally, proxy endpoint, wormhole", () => {
+    const banner = getPeerConnectionBanner(mixedContentBlocked)!;
+    const labels = banner.actions.map((a) => a.label.toLowerCase());
+    expect(labels.some((l) => l.includes("locally"))).toBe(true);
+    expect(labels.some((l) => l.includes("proxy"))).toBe(true);
+    expect(labels.some((l) => l.includes("wormhole"))).toBe(true);
+  });
+
+  test("wormhole action is explicit about commands-not-REST scope", () => {
+    // Load-bearing: this is the iteration-5 grounding catch encoded in UX.
+    // The user must NOT think wormhole is a REST proxy.
+    const banner = getPeerConnectionBanner(mixedContentBlocked)!;
+    const wormholeAction = banner.actions.find((a) =>
+      a.label.toLowerCase().includes("wormhole"),
+    );
+    expect(wormholeAction).not.toBeUndefined();
+    expect(wormholeAction!.description.toLowerCase()).toContain("not for arbitrary rest");
+  });
+
+  test("source field round-trips the original PeerConnection", () => {
+    const banner = getPeerConnectionBanner(mixedContentBlocked)!;
+    expect(banner.source).toBe(mixedContentBlocked);
+  });
+});
+
+// ---- getPeerConnectionBanner — invalid ----------------------------------
+
+describe("getPeerConnectionBanner — invalid", () => {
+  test("returns warning severity (not error)", () => {
+    const banner = getPeerConnectionBanner(invalid);
+    expect(banner).not.toBeNull();
+    expect(banner!.severity).toBe("warning");
+    // Rationale: same-origin still works, the page is functional, just
+    // the host param is broken. Warning is more accurate than error.
+  });
+
+  test("message includes the offending input", () => {
+    const banner = getPeerConnectionBanner(invalid)!;
+    expect(banner.message).toContain("garbage!!!");
+  });
+
+  test("message includes the parser reason", () => {
+    const banner = getPeerConnectionBanner(invalid)!;
+    expect(banner.message).toContain("unrecognized host shape");
+  });
+
+  test("actions include 'remove host param' fallback", () => {
+    const banner = getPeerConnectionBanner(invalid)!;
+    const labels = banner.actions.map((a) => a.label.toLowerCase());
+    expect(labels.some((l) => l.includes("remove"))).toBe(true);
+  });
+
+  test("actions include 'fix the URL' with concrete examples", () => {
+    const banner = getPeerConnectionBanner(invalid)!;
+    const fixAction = banner.actions.find((a) => a.label.toLowerCase().includes("fix"));
+    expect(fixAction).not.toBeUndefined();
+    expect(fixAction!.description).toContain("oracle-world");
+    expect(fixAction!.description).toContain("10.20.0.7");
+  });
+});
+
+// ---- shouldShowBanner ---------------------------------------------------
+
+describe("shouldShowBanner", () => {
+  test("false for same-origin", () => {
+    expect(shouldShowBanner(sameOrigin)).toBe(false);
+  });
+
+  test("false for direct", () => {
+    expect(shouldShowBanner(direct)).toBe(false);
+  });
+
+  test("true for mixed-content-blocked", () => {
+    expect(shouldShowBanner(mixedContentBlocked)).toBe(true);
+  });
+
+  test("true for invalid", () => {
+    expect(shouldShowBanner(invalid)).toBe(true);
+  });
+});
+
+// ---- bannerSeverity -----------------------------------------------------
+
+describe("bannerSeverity", () => {
+  test("null for same-origin", () => {
+    expect(bannerSeverity(sameOrigin)).toBeNull();
+  });
+
+  test("null for direct", () => {
+    expect(bannerSeverity(direct)).toBeNull();
+  });
+
+  test("error for mixed-content-blocked", () => {
+    expect(bannerSeverity(mixedContentBlocked)).toBe("error");
+  });
+
+  test("warning for invalid", () => {
+    expect(bannerSeverity(invalid)).toBe("warning");
+  });
+});
+
+// ---- The four-kind invariant lock ---------------------------------------
+
+describe("the four-kind invariant", () => {
+  // If PeerConnection ever gains a fifth kind, the exhaustiveness `never`
+  // check in getPeerConnectionBanner will fail at compile time. This test
+  // documents the runtime expectation that all four current kinds are
+  // covered, with the right banner-or-null verdict for each.
+
+  test("all four PeerConnection kinds are handled with deliberate verdicts", () => {
+    expect(getPeerConnectionBanner(sameOrigin)).toBeNull();
+    expect(getPeerConnectionBanner(direct)).toBeNull();
+    expect(getPeerConnectionBanner(mixedContentBlocked)).not.toBeNull();
+    expect(getPeerConnectionBanner(invalid)).not.toBeNull();
+  });
+});

--- a/src/lib/peerConnectionBanner.ts
+++ b/src/lib/peerConnectionBanner.ts
@@ -1,0 +1,179 @@
+/**
+ * peerConnectionBanner — derive user-facing banner content from a
+ * `PeerConnection` classification, so the UI can render a clear error
+ * message instead of letting the user stare at a mysterious fetch failure.
+ *
+ * PROTOTYPE — iteration 8 of the federation-join-easy /loop. Drafted on the
+ * `feat/wormhole-client-draft` branch alongside the rest of the maw-ui
+ * federation bundle. See
+ * `mawui-oracle/ψ/writing/federation-join-easy.md` for context.
+ *
+ * ## Why this is a pure helper instead of a React component
+ *
+ * The component layer is a 5-line wrapper around this helper:
+ *
+ *   ```tsx
+ *   const banner = getPeerConnectionBanner(pc);
+ *   if (!banner) return null;
+ *   return <Banner severity={banner.severity} title={banner.title}>...</Banner>;
+ *   ```
+ *
+ * Keeping the logic in a pure helper means:
+ *   - Zero DOM dependency for testing (bun test works natively)
+ *   - The classifier output can be unit-tested independently of any UI library
+ *   - A future migration from React to anything else doesn't touch this file
+ *   - The helper can be reused by non-banner UI (toasts, tooltips, modal dialogs)
+ *
+ * The actual `peerConnectionBanner.tsx` React component is deferred to
+ * iteration 9+ — when there's a real call site that needs it. YAGNI until
+ * a caller exists.
+ *
+ * ## What gets a banner
+ *
+ * | PeerConnection.kind        | Banner? | Severity |
+ * |---                          |---      |---       |
+ * | `same-origin`               | no      | (n/a)    |
+ * | `direct`                    | no      | (n/a)    |
+ * | `mixed-content-blocked`     | YES     | error    |
+ * | `invalid`                   | YES     | warning  |
+ *
+ * The `same-origin` and `direct` cases are happy paths — the caller can
+ * fetch normally and there's nothing to surface.
+ *
+ * The `mixed-content-blocked` case is the load-bearing one. Without this
+ * banner, the user clicks a federation link and watches the page fail to
+ * load with no explanation. With the banner, they see exactly why and
+ * what to do.
+ *
+ * The `invalid` case is a malformed `?host=` value — the user (or whoever
+ * generated the link) made a typo. Surfaced as a warning, not an error,
+ * because the page still works in the same-origin sense.
+ */
+
+import type { PeerConnection } from "./peerConnection";
+
+// ---- Types ---------------------------------------------------------------
+
+export type BannerSeverity = "error" | "warning" | "info";
+
+export interface BannerAction {
+  /** Action label, e.g. "Run locally" */
+  label: string;
+  /** Free-form one-line description of what this action does */
+  description: string;
+  /** Optional href if the action is a link (e.g. to docs); UI may render as button otherwise */
+  href?: string;
+}
+
+export interface PeerConnectionBanner {
+  severity: BannerSeverity;
+  title: string;
+  message: string;
+  /** Optional concrete actions the user can take to fix or work around the situation */
+  actions: BannerAction[];
+  /** The original `PeerConnection` for advanced consumers */
+  source: PeerConnection;
+}
+
+// ---- The helper ----------------------------------------------------------
+
+/**
+ * Derive banner content from a `PeerConnection` classification.
+ *
+ * Returns `null` for happy-path kinds (`same-origin`, `direct`) — the
+ * caller renders nothing. Returns a populated `PeerConnectionBanner` for
+ * `mixed-content-blocked` and `invalid` — the caller renders an error/
+ * warning UI.
+ */
+export function getPeerConnectionBanner(pc: PeerConnection): PeerConnectionBanner | null {
+  switch (pc.kind) {
+    case "same-origin":
+    case "direct":
+      // Happy paths — nothing to surface
+      return null;
+
+    case "mixed-content-blocked":
+      return {
+        severity: "error",
+        title: "Cannot reach this peer from a secure origin",
+        message:
+          `The browser blocks HTTPS pages from fetching plain HTTP resources. ` +
+          `This page is loaded over HTTPS, but the peer at ${pc.peerUrl} only ` +
+          `accepts HTTP — so direct fetches are blocked at the protocol level ` +
+          `(this isn't a CORS issue and can't be fixed with a header).`,
+        actions: [
+          {
+            label: "Run maw-ui locally",
+            description:
+              "Use `maw ui --from-ci` to serve the lens from http://localhost. " +
+              "Same-origin fetches to your local backend work without browser blocks.",
+          },
+          {
+            label: "Use the proxy endpoint",
+            description:
+              "POST /api/proxy on your local backend relays REST calls to HTTP peers. " +
+              "Works for the v1 read-only endpoints (config, feed, sessions, teams, etc.).",
+          },
+          {
+            label: "Use /wormhole for commands",
+            description:
+              "POST /api/wormhole/request on your local backend relays signed commands " +
+              "(/dig, /trace, /recap) to any peer. NOT for arbitrary REST reads.",
+          },
+        ],
+        source: pc,
+      };
+
+    case "invalid":
+      return {
+        severity: "warning",
+        title: "Malformed `?host=` value",
+        message:
+          `The host parameter "${pc.input}" couldn't be parsed. ` +
+          `Expected one of: \`host:port\`, \`http://host\`, or \`https://host\`. ` +
+          `Reason: ${pc.reason}.`,
+        actions: [
+          {
+            label: "Remove the host parameter",
+            description:
+              "Loading the page without `?host=` falls back to the same-origin backend, " +
+              "which works as long as your local maw-js is running.",
+          },
+          {
+            label: "Fix the URL",
+            description:
+              "Try `?host=oracle-world` (named peer), `?host=10.20.0.7:3456` (LAN), " +
+              "or `?host=https://white.local:3456` (explicit protocol).",
+          },
+        ],
+        source: pc,
+      };
+
+    default: {
+      // Exhaustiveness check — if a new kind is added to PeerConnection,
+      // TypeScript will complain here and force a deliberate update.
+      const _exhaustive: never = pc;
+      void _exhaustive;
+      return null;
+    }
+  }
+}
+
+// ---- Convenience helpers -------------------------------------------------
+
+/**
+ * Should the UI render any banner for this peer? Convenience wrapper for
+ * conditional rendering: `{shouldShowBanner(pc) && <Banner ... />}`.
+ */
+export function shouldShowBanner(pc: PeerConnection): boolean {
+  return getPeerConnectionBanner(pc) !== null;
+}
+
+/**
+ * Pull just the severity for cases where the UI needs it before computing
+ * the full banner content (e.g. setting an icon color).
+ */
+export function bannerSeverity(pc: PeerConnection): BannerSeverity | null {
+  const banner = getPeerConnectionBanner(pc);
+  return banner ? banner.severity : null;
+}

--- a/src/lib/peerProxyClient.test.ts
+++ b/src/lib/peerProxyClient.test.ts
@@ -1,0 +1,337 @@
+/**
+ * Tests for PeerProxyClient — companion to maw-js POST /api/proxy.
+ *
+ * PROTOTYPE — iteration 7 of the federation-join-easy /loop, on
+ * feat/wormhole-client-draft. See
+ * mawui-oracle/ψ/writing/federation-join-easy.md for context.
+ *
+ * Mirrors wormholeClient.test.ts conventions — pure helpers, construction,
+ * async fetch interactions via globalThis.fetch mock swap. Locks the
+ * load-bearing invariant that GET/HEAD/OPTIONS are readonly and that the
+ * client surfaces typed errors with .status + .body.
+ */
+
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import {
+  PeerProxyClient,
+  generateProxyAnonSignature,
+  type PeerProxyResponse,
+} from "./peerProxyClient";
+
+// ---- Pure helper tests ---------------------------------------------------
+
+describe("generateProxyAnonSignature", () => {
+  test("produces a signature in [host:anon-<nonce>] shape", () => {
+    const sig = generateProxyAnonSignature("local.example.com");
+    expect(sig).toMatch(/^\[local\.example\.com:anon-[a-f0-9]{8}\]$/);
+  });
+
+  test("different calls produce different nonces", () => {
+    const a = generateProxyAnonSignature("host-x");
+    const b = generateProxyAnonSignature("host-x");
+    expect(a).not.toBe(b);
+  });
+
+  test("preserves hostnames with dots, dashes, and ports", () => {
+    const sig = generateProxyAnonSignature("oracle-world.laris.co:3456");
+    expect(sig.startsWith("[oracle-world.laris.co:3456:anon-")).toBe(true);
+  });
+
+  test("nonce is exactly 8 hex chars (×20 reps)", () => {
+    for (let i = 0; i < 20; i++) {
+      const sig = generateProxyAnonSignature("h");
+      const match = sig.match(/anon-([a-f0-9]+)\]$/);
+      expect(match).not.toBeNull();
+      expect(match![1].length).toBe(8);
+    }
+  });
+});
+
+describe("PeerProxyClient.isReadOnlyMethod (static helper)", () => {
+  test.each(["GET", "HEAD", "OPTIONS"])("%s is readonly", (method) => {
+    expect(PeerProxyClient.isReadOnlyMethod(method)).toBe(true);
+  });
+
+  test.each(["POST", "PUT", "PATCH", "DELETE"])("%s is NOT readonly", (method) => {
+    expect(PeerProxyClient.isReadOnlyMethod(method)).toBe(false);
+  });
+
+  test("case-insensitive", () => {
+    expect(PeerProxyClient.isReadOnlyMethod("get")).toBe(true);
+    expect(PeerProxyClient.isReadOnlyMethod("Post")).toBe(false);
+    expect(PeerProxyClient.isReadOnlyMethod("PUT")).toBe(false);
+  });
+
+  test("mirrors server-side semantics (load-bearing invariant)", () => {
+    // The server (maw-js src/api/proxy.ts) classifies these exact 3 methods
+    // as readonly. If either side adds or removes a method, this test
+    // pair (here + maw-js test/proxy.test.ts isReadOnlyMethod) will diverge.
+    const SERVER_READONLY = ["GET", "HEAD", "OPTIONS"];
+    for (const m of SERVER_READONLY) {
+      expect(PeerProxyClient.isReadOnlyMethod(m)).toBe(true);
+    }
+    const SERVER_MUTATING = ["POST", "PUT", "PATCH", "DELETE"];
+    for (const m of SERVER_MUTATING) {
+      expect(PeerProxyClient.isReadOnlyMethod(m)).toBe(false);
+    }
+  });
+});
+
+describe("PeerProxyClient.parseJsonBody (static helper)", () => {
+  function fakeResponse(body: string): PeerProxyResponse {
+    return {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body,
+      from: "http://stub:3456",
+      elapsed_ms: 1,
+      trust_tier: "readonly_method",
+    };
+  }
+
+  test("parses valid JSON", () => {
+    const res = fakeResponse('{"a": 1, "b": "two"}');
+    expect(PeerProxyClient.parseJsonBody<{ a: number; b: string }>(res)).toEqual({
+      a: 1,
+      b: "two",
+    });
+  });
+
+  test("parses arrays", () => {
+    const res = fakeResponse("[1,2,3]");
+    expect(PeerProxyClient.parseJsonBody<number[]>(res)).toEqual([1, 2, 3]);
+  });
+
+  test("throws on malformed JSON", () => {
+    const res = fakeResponse("not json {");
+    expect(() => PeerProxyClient.parseJsonBody(res)).toThrow(/failed to parse response body as JSON/);
+  });
+
+  test("throws on empty body", () => {
+    const res = fakeResponse("");
+    expect(() => PeerProxyClient.parseJsonBody(res)).toThrow();
+  });
+});
+
+// ---- Construction tests --------------------------------------------------
+
+describe("PeerProxyClient — construction", () => {
+  test("stores peer + generates anon signature at construction", () => {
+    const c = new PeerProxyClient("white", "local.example.com");
+    expect(c.peer).toBe("white");
+    expect(c.signature).toMatch(/^\[local\.example\.com:anon-[a-f0-9]{8}\]$/);
+  });
+
+  test("signature is stable for instance lifetime", () => {
+    const c = new PeerProxyClient("white", "local.example.com");
+    const sig1 = c.signature;
+    const sig2 = c.signature;
+    expect(sig1).toBe(sig2);
+  });
+
+  test("two instances produce different signatures", () => {
+    const a = new PeerProxyClient("white", "local.example.com");
+    const b = new PeerProxyClient("white", "local.example.com");
+    expect(a.signature).not.toBe(b.signature);
+  });
+
+  test("defaults originHost to window.location.host when available", () => {
+    (globalThis as any).window = { location: { host: "stubbed.example.com" } };
+    try {
+      const c = new PeerProxyClient("white");
+      expect(c.signature.startsWith("[stubbed.example.com:anon-")).toBe(true);
+    } finally {
+      delete (globalThis as any).window;
+    }
+  });
+
+  test("falls back to 'unknown-origin' when window is undefined", () => {
+    delete (globalThis as any).window;
+    const c = new PeerProxyClient("white");
+    expect(c.signature.startsWith("[unknown-origin:anon-")).toBe(true);
+  });
+});
+
+// ---- fetch mocking -------------------------------------------------------
+
+describe("PeerProxyClient — fetch interactions", () => {
+  let originalFetch: typeof fetch;
+  let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchCalls = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+    globalThis.fetch = (async (input: any, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.url;
+      fetchCalls.push({ url, init });
+      return handler(url, init);
+    }) as typeof fetch;
+  }
+
+  function okProxyResponse(overrides: Partial<PeerProxyResponse> = {}): PeerProxyResponse {
+    return {
+      status: 200,
+      headers: { "content-type": "application/json" },
+      body: '{"ok": true}',
+      from: "http://10.20.0.7:3456",
+      elapsed_ms: 42,
+      trust_tier: "readonly_method",
+      ...overrides,
+    };
+  }
+
+  test("ensureSession() GETs /api/proxy/session", async () => {
+    mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const c = new PeerProxyClient("white", "local.example.com");
+    await c.ensureSession();
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe("/api/proxy/session");
+  });
+
+  test("ensureSession() is idempotent (3 calls → 1 fetch)", async () => {
+    mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const c = new PeerProxyClient("white", "local.example.com");
+    await c.ensureSession();
+    await c.ensureSession();
+    await c.ensureSession();
+    expect(fetchCalls.length).toBe(1);
+  });
+
+  test("ensureSession() throws on non-2xx with descriptive error", async () => {
+    mockFetch(() => new Response("forbidden", { status: 403 }));
+    const c = new PeerProxyClient("white", "local.example.com");
+    await expect(c.ensureSession()).rejects.toThrow(/peerProxy: session bootstrap failed.*403/);
+  });
+
+  test("get() POSTs the correct body shape with method=GET", async () => {
+    mockFetch((url) => {
+      if (url === "/api/proxy/session") return new Response('{"ok":true}', { status: 200 });
+      return new Response(JSON.stringify(okProxyResponse()), { status: 200 });
+    });
+    const c = new PeerProxyClient("white", "local.example.com");
+    await c.get("/api/config");
+    const postCall = fetchCalls[1];
+    expect(postCall.url).toBe("/api/proxy");
+    expect(postCall.init?.method).toBe("POST");
+    expect(postCall.init?.credentials).toBe("same-origin");
+    const body = JSON.parse(postCall.init!.body as string);
+    expect(body.peer).toBe("white");
+    expect(body.method).toBe("GET");
+    expect(body.path).toBe("/api/config");
+    expect(body.signature).toMatch(/^\[local\.example\.com:anon-/);
+    expect(body.body).toBeUndefined();
+  });
+
+  test("post() includes body in the proxy envelope", async () => {
+    mockFetch((url) => {
+      if (url === "/api/proxy/session") return new Response('{"ok":true}', { status: 200 });
+      return new Response(JSON.stringify(okProxyResponse()), { status: 200 });
+    });
+    const c = new PeerProxyClient("white", "local.example.com");
+    await c.post("/api/ping", '{"url": "http://other"}');
+    const postBody = JSON.parse(fetchCalls[1].init!.body as string);
+    expect(postBody.method).toBe("POST");
+    expect(postBody.body).toBe('{"url": "http://other"}');
+  });
+
+  test("get() auto-bootstraps session if caller forgets", async () => {
+    mockFetch((url) => {
+      if (url === "/api/proxy/session") return new Response('{"ok":true}', { status: 200 });
+      return new Response(JSON.stringify(okProxyResponse()), { status: 200 });
+    });
+    const c = new PeerProxyClient("white", "local.example.com");
+    await c.get("/api/config"); // no ensureSession() call first
+    expect(fetchCalls[0].url).toBe("/api/proxy/session");
+    expect(fetchCalls[1].url).toBe("/api/proxy");
+  });
+
+  test("returns typed PeerProxyResponse on success", async () => {
+    mockFetch((url) => {
+      if (url === "/api/proxy/session") return new Response('{"ok":true}', { status: 200 });
+      return new Response(
+        JSON.stringify({
+          status: 200,
+          headers: { "content-type": "application/json" },
+          body: '{"sessions": []}',
+          from: "http://10.20.0.7:3456",
+          elapsed_ms: 87,
+          trust_tier: "readonly_method",
+        }),
+        { status: 200 },
+      );
+    });
+    const c = new PeerProxyClient("white", "local.example.com");
+    const result: PeerProxyResponse = await c.get("/api/sessions");
+    expect(result.status).toBe(200);
+    expect(result.body).toBe('{"sessions": []}');
+    expect(result.from).toBe("http://10.20.0.7:3456");
+    expect(result.elapsed_ms).toBe(87);
+    expect(result.trust_tier).toBe("readonly_method");
+  });
+
+  test("throws typed error with .status and .body on non-2xx", async () => {
+    mockFetch((url) => {
+      if (url === "/api/proxy/session") return new Response('{"ok":true}', { status: 200 });
+      return new Response(
+        JSON.stringify({ error: "mutation_denied", hint: "anon is read-only" }),
+        { status: 403 },
+      );
+    });
+    const c = new PeerProxyClient("white", "local.example.com");
+    try {
+      await c.post("/api/ping", '{"url":"x"}');
+      expect.unreachable("should have thrown");
+    } catch (err: any) {
+      expect(err.message).toContain("peerProxy: 403");
+      expect(err.message).toContain("mutation_denied");
+      expect(err.message).toContain("POST /api/ping");
+      expect(err.status).toBe(403);
+      expect(err.body.error).toBe("mutation_denied");
+    }
+  });
+
+  test("HTTP method shortcuts call request() with correct method", async () => {
+    mockFetch((url) => {
+      if (url === "/api/proxy/session") return new Response('{"ok":true}', { status: 200 });
+      return new Response(JSON.stringify(okProxyResponse()), { status: 200 });
+    });
+    const c = new PeerProxyClient("white", "local.example.com");
+    await c.ensureSession();
+
+    await c.get("/api/config");
+    await c.head("/api/config");
+    await c.options("/api/config");
+    await c.post("/api/config", "{}");
+    await c.put("/api/config", "{}");
+    await c.patch("/api/config", "{}");
+    await c.delete("/api/config");
+
+    // Skip the session call (index 0); 7 method calls follow
+    const methodsCalled = fetchCalls
+      .slice(1)
+      .map((call) => JSON.parse(call.init!.body as string).method);
+    expect(methodsCalled).toEqual(["GET", "HEAD", "OPTIONS", "POST", "PUT", "PATCH", "DELETE"]);
+  });
+
+  test("get() round-trips JSON via parseJsonBody", async () => {
+    mockFetch((url) => {
+      if (url === "/api/proxy/session") return new Response('{"ok":true}', { status: 200 });
+      return new Response(
+        JSON.stringify(okProxyResponse({ body: '{"hello":"world","count":42}' })),
+        { status: 200 },
+      );
+    });
+    const c = new PeerProxyClient("white", "local.example.com");
+    const res = await c.get("/api/config");
+    const parsed = PeerProxyClient.parseJsonBody<{ hello: string; count: number }>(res);
+    expect(parsed.hello).toBe("world");
+    expect(parsed.count).toBe(42);
+  });
+});

--- a/src/lib/peerProxyClient.ts
+++ b/src/lib/peerProxyClient.ts
@@ -1,0 +1,227 @@
+/**
+ * PeerProxyClient — browser-side client for `POST /api/proxy`.
+ *
+ * PROTOTYPE — iteration 7 of the federation-join-easy /loop. Drafted on the
+ * `feat/wormhole-client-draft` branch (alongside `WormholeClient` and
+ * `peerConnection`). See
+ * `mawui-oracle/ψ/writing/federation-join-easy.md` for full context.
+ *
+ * ## Companion to /api/proxy (NOT /api/wormhole)
+ *
+ * This client pairs with `maw-js/src/api/proxy.ts` (server-side, drafted on
+ * `feat/api-proxy-http-peers`). It is a SEPARATE client from
+ * `wormholeClient.ts` because it serves a different need:
+ *
+ *   - **`WormholeClient`** — signed command execution (`/dig`, `/trace`,
+ *     `/recap`). RPC-shaped. Returns command output strings.
+ *   - **`PeerProxyClient`** — generic HTTP REST relay. Returns full HTTP
+ *     responses (status, headers, body). Used when an HTTPS origin needs
+ *     to read REST data from an HTTP-LAN peer (the mixed-content-blocked
+ *     case named by `peerConnection.ts`).
+ *
+ * Conflating them was the iteration-5 grounding catch. Keeping them as
+ * separate clients with separate session cookies and separate trust models
+ * is the iteration-6 architectural commitment.
+ *
+ * ## Trust model match-up with the server
+ *
+ * The server enforces:
+ *   - GET / HEAD / OPTIONS: always permitted (HTTP read-only semantics)
+ *   - POST / PUT / PATCH / DELETE: require origin in `config.proxy.shellPeers`
+ *   - anon-* never on the allowlist by convention
+ *
+ * The client mirrors this with `PeerProxyClient.isReadOnlyMethod()` for UI
+ * gating — disable a "save" button before the user submits and gets a 403
+ * round-trip.
+ *
+ * ## Path allowlist (server-side defense in depth)
+ *
+ * Even GET requests are restricted to a fixed allowlist of v1 REST
+ * endpoints. The client does NOT enforce this — the server is authoritative,
+ * and the client should not duplicate the list (it would drift). Callers
+ * that hit a non-allowlisted path get `403 path_not_proxyable` from the
+ * server, which the client surfaces as a typed error.
+ *
+ * ## Status
+ *
+ * - Iteration 7 prototype, on `feat/wormhole-client-draft` (the maw-ui
+ *   federation bundle branch). PR-time decision: split into separate PRs
+ *   for peerConnection / WormholeClient / PeerProxyClient, or ship as one.
+ * - Companion server endpoint `POST /api/proxy` lives on the SEPARATE
+ *   `feat/api-proxy-http-peers` branch on maw-js. Both will be filed
+ *   together when Q#5 (deploy ownership) is answered.
+ */
+
+// ---- Types ---------------------------------------------------------------
+
+export type ProxyMethod = "GET" | "HEAD" | "OPTIONS" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+export interface PeerProxyResponse {
+  /** Upstream HTTP status code from the peer */
+  status: number;
+  /** Subset of safe response headers (content-type, cache-control, etag, last-modified) */
+  headers: Record<string, string>;
+  /** Raw response body as a string */
+  body: string;
+  /** Which peer URL served the response */
+  from: string;
+  /** Round-trip time including local backend relay + peer execution */
+  elapsed_ms: number;
+  /** Trust tier the backend applied: "readonly_method" or "shell_allowlisted" */
+  trust_tier: "readonly_method" | "shell_allowlisted";
+}
+
+export interface PeerProxyError {
+  error: string;
+  [key: string]: unknown;
+}
+
+// ---- Signature generation ------------------------------------------------
+
+/**
+ * Generate an anonymous signature for a browser visitor. Same shape as
+ * `generateAnonSignature` in `wormholeClient.ts` — duplicated here to avoid
+ * cross-file coupling between two prototype clients. If we ever share this,
+ * it moves to `src/lib/signature.ts` with explicit dual-consumer tests.
+ */
+export function generateProxyAnonSignature(originHost: string): string {
+  let nonce: string;
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    nonce = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+  } else {
+    nonce = Math.random().toString(16).slice(2, 10).padEnd(8, "0");
+  }
+  return `[${originHost}:anon-${nonce}]`;
+}
+
+// ---- Client --------------------------------------------------------------
+
+export class PeerProxyClient {
+  readonly peer: string;
+  readonly signature: string;
+  private sessionReady = false;
+
+  constructor(peer: string, originHost?: string) {
+    this.peer = peer;
+    const host =
+      originHost ??
+      (typeof window !== "undefined" ? window.location.host : "unknown-origin");
+    this.signature = generateProxyAnonSignature(host);
+  }
+
+  /**
+   * Bootstrap the proxy session cookie. Must be called once before any
+   * `request()` / `get()` / `post()` calls in production. Idempotent —
+   * safe to call multiple times.
+   */
+  async ensureSession(): Promise<void> {
+    if (this.sessionReady) return;
+    const res = await fetch("/api/proxy/session", {
+      credentials: "same-origin",
+    });
+    if (!res.ok) {
+      throw new Error(
+        `peerProxy: session bootstrap failed (${res.status} ${res.statusText})`,
+      );
+    }
+    this.sessionReady = true;
+  }
+
+  /**
+   * Generic request method. Auto-bootstraps the session if the caller
+   * forgets. Returns a typed `PeerProxyResponse` on success; throws on
+   * non-2xx with `.status` and `.body` attached.
+   */
+  async request(
+    method: ProxyMethod,
+    path: string,
+    body?: string,
+  ): Promise<PeerProxyResponse> {
+    if (!this.sessionReady) {
+      await this.ensureSession();
+    }
+
+    const res = await fetch("/api/proxy", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        peer: this.peer,
+        method,
+        path,
+        body,
+        signature: this.signature,
+      }),
+    });
+
+    if (!res.ok) {
+      const errBody = (await res.json().catch(() => ({}))) as PeerProxyError;
+      const err = new Error(
+        `peerProxy: ${res.status} ${errBody.error ?? res.statusText} (peer=${this.peer}, ${method} ${path})`,
+      );
+      (err as any).status = res.status;
+      (err as any).body = errBody;
+      throw err;
+    }
+
+    return (await res.json()) as PeerProxyResponse;
+  }
+
+  // --- HTTP method shortcuts ---
+
+  get(path: string): Promise<PeerProxyResponse> {
+    return this.request("GET", path);
+  }
+
+  head(path: string): Promise<PeerProxyResponse> {
+    return this.request("HEAD", path);
+  }
+
+  options(path: string): Promise<PeerProxyResponse> {
+    return this.request("OPTIONS", path);
+  }
+
+  post(path: string, body?: string): Promise<PeerProxyResponse> {
+    return this.request("POST", path, body);
+  }
+
+  put(path: string, body?: string): Promise<PeerProxyResponse> {
+    return this.request("PUT", path, body);
+  }
+
+  patch(path: string, body?: string): Promise<PeerProxyResponse> {
+    return this.request("PATCH", path, body);
+  }
+
+  delete(path: string): Promise<PeerProxyResponse> {
+    return this.request("DELETE", path);
+  }
+
+  // --- Static helpers ---
+
+  /**
+   * Mirrors the server-side trust boundary: GET / HEAD / OPTIONS are
+   * permitted for anonymous browser visitors; mutations require the
+   * origin to be on `config.proxy.shellPeers`. UI code should disable
+   * mutation buttons for anon visitors before they hit a 403.
+   */
+  static isReadOnlyMethod(method: string): boolean {
+    const m = method.toUpperCase();
+    return m === "GET" || m === "HEAD" || m === "OPTIONS";
+  }
+
+  /**
+   * Convenience helper: parse a `PeerProxyResponse.body` as JSON. Returns
+   * the parsed object or throws if the body is malformed. Useful for
+   * REST endpoints that return JSON (the v1 path allowlist is mostly JSON).
+   */
+  static parseJsonBody<T = unknown>(response: PeerProxyResponse): T {
+    try {
+      return JSON.parse(response.body) as T;
+    } catch (err: any) {
+      throw new Error(
+        `peerProxy: failed to parse response body as JSON (${err?.message ?? "unknown error"})`,
+      );
+    }
+  }
+}

--- a/src/lib/wormholeClient.test.ts
+++ b/src/lib/wormholeClient.test.ts
@@ -1,0 +1,301 @@
+/**
+ * Tests for WormholeClient — browser-side client for POST /api/wormhole/request.
+ * Companion to src/lib/wormholeClient.ts and maw-js/test/wormhole.test.ts.
+ *
+ * PROTOTYPE — iteration 4 of the federation-join-easy /loop, drafted on the
+ * feat/wormhole-client-draft branch. See
+ * mawui-oracle/ψ/writing/federation-join-easy.md for context.
+ *
+ * maw-ui has no explicit test runner in package.json (only vite scripts), but
+ * `bun test` works natively on `.test.ts` files and the WormholeClient has no
+ * React/DOM/vite dependencies beyond `fetch` and `crypto.randomUUID` which are
+ * both globals in modern bun. Runs via: `bun test src/lib/wormholeClient.test.ts`
+ * from the maw-ui repo root.
+ */
+
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import {
+  WormholeClient,
+  generateAnonSignature,
+  type WormholeResponse,
+} from "./wormholeClient";
+
+// ---- Pure helper tests ---------------------------------------------------
+
+describe("generateAnonSignature", () => {
+  test("produces a signature in [host:anon-<nonce>] shape", () => {
+    const sig = generateAnonSignature("local.example.com");
+    expect(sig).toMatch(/^\[local\.example\.com:anon-[a-f0-9]{8}\]$/);
+  });
+
+  test("different calls produce different nonces (randomness check)", () => {
+    const a = generateAnonSignature("host-x");
+    const b = generateAnonSignature("host-x");
+    // Not a cryptographic test — just that they don't collide in the common case.
+    // If this ever flakes, the underlying RNG is broken.
+    expect(a).not.toBe(b);
+  });
+
+  test("preserves hostnames with dots, dashes, and colons in the host portion", () => {
+    const sig = generateAnonSignature("oracle-world.laris.co:3456");
+    expect(sig.startsWith("[oracle-world.laris.co:3456:anon-")).toBe(true);
+  });
+
+  test("nonce is exactly 8 hex characters", () => {
+    for (let i = 0; i < 20; i++) {
+      const sig = generateAnonSignature("h");
+      const match = sig.match(/anon-([a-f0-9]+)\]$/);
+      expect(match).not.toBeNull();
+      expect(match![1].length).toBe(8);
+    }
+  });
+});
+
+describe("WormholeClient.isReadOnlyCmd (static helper)", () => {
+  test.each([
+    "/dig",
+    "/dig --all 5",
+    "/trace",
+    "/recap",
+    "/recap --now deep",
+    "/standup",
+    "/who-are-you",
+    "/philosophy",
+    "/where-we-are",
+  ])("permits %s", (cmd) => {
+    expect(WormholeClient.isReadOnlyCmd(cmd)).toBe(true);
+  });
+
+  test.each([
+    "/awaken",
+    "/commit",
+    "/rrr",
+    "/incubate foo/bar",
+    "/diggy --deep",
+    "dig",
+    "",
+  ])("denies %s", (cmd) => {
+    expect(WormholeClient.isReadOnlyCmd(cmd)).toBe(false);
+  });
+
+  test("mirrors the server-side whitelist (same 7 verbs)", () => {
+    // Load-bearing invariant: client gates + server enforcement must agree
+    // so we don't show a UI button that the backend will 403.
+    const SERVER_WHITELIST = [
+      "/dig",
+      "/trace",
+      "/recap",
+      "/standup",
+      "/who-are-you",
+      "/philosophy",
+      "/where-we-are",
+    ];
+    for (const verb of SERVER_WHITELIST) {
+      expect(WormholeClient.isReadOnlyCmd(verb)).toBe(true);
+    }
+  });
+});
+
+// ---- WormholeClient class tests ------------------------------------------
+
+describe("WormholeClient — construction", () => {
+  test("stores peer + generates anon signature at construction", () => {
+    const wh = new WormholeClient("white", "local.example.com");
+    expect(wh.peer).toBe("white");
+    expect(wh.signature).toMatch(/^\[local\.example\.com:anon-[a-f0-9]{8}\]$/);
+  });
+
+  test("signature is stable for the lifetime of one instance", () => {
+    const wh = new WormholeClient("white", "local.example.com");
+    const sig1 = wh.signature;
+    const sig2 = wh.signature;
+    expect(sig1).toBe(sig2);
+  });
+
+  test("two instances produce different signatures", () => {
+    const a = new WormholeClient("white", "local.example.com");
+    const b = new WormholeClient("white", "local.example.com");
+    expect(a.signature).not.toBe(b.signature);
+  });
+
+  test("defaults originHost to window.location.host when available", () => {
+    // Stub a minimal window object
+    (globalThis as any).window = { location: { host: "stubbed.example.com" } };
+    try {
+      const wh = new WormholeClient("white");
+      expect(wh.signature.startsWith("[stubbed.example.com:anon-")).toBe(true);
+    } finally {
+      delete (globalThis as any).window;
+    }
+  });
+
+  test("falls back to 'unknown-origin' in non-browser environments", () => {
+    // Ensure no window object
+    delete (globalThis as any).window;
+    const wh = new WormholeClient("white");
+    expect(wh.signature.startsWith("[unknown-origin:anon-")).toBe(true);
+  });
+});
+
+// ---- fetch mocking -------------------------------------------------------
+
+describe("WormholeClient — fetch interactions", () => {
+  let originalFetch: typeof fetch;
+  let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+
+  beforeEach(() => {
+    originalFetch = globalThis.fetch;
+    fetchCalls = [];
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  function mockFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+    globalThis.fetch = (async (input: any, init?: RequestInit) => {
+      const url = typeof input === "string" ? input : input.url;
+      fetchCalls.push({ url, init });
+      return handler(url, init);
+    }) as typeof fetch;
+  }
+
+  test("ensureSession() GETs /api/wormhole/session", async () => {
+    mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const wh = new WormholeClient("white", "local.example.com");
+    await wh.ensureSession();
+    expect(fetchCalls.length).toBe(1);
+    expect(fetchCalls[0].url).toBe("/api/wormhole/session");
+  });
+
+  test("ensureSession() is idempotent (multiple calls → one fetch)", async () => {
+    mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const wh = new WormholeClient("white", "local.example.com");
+    await wh.ensureSession();
+    await wh.ensureSession();
+    await wh.ensureSession();
+    expect(fetchCalls.length).toBe(1);
+  });
+
+  test("ensureSession() throws on non-2xx response", async () => {
+    mockFetch(() => new Response("forbidden", { status: 403 }));
+    const wh = new WormholeClient("white", "local.example.com");
+    await expect(wh.ensureSession()).rejects.toThrow(/session bootstrap failed.*403/);
+  });
+
+  test("request() auto-bootstraps session if caller forgets", async () => {
+    mockFetch((url) => {
+      if (url === "/api/wormhole/session") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ output: "ok", from: "http://white:3456", elapsed_ms: 42, status: 200, trust_tier: "readonly" }),
+        { status: 200 },
+      );
+    });
+    const wh = new WormholeClient("white", "local.example.com");
+    const result = await wh.request("/dig", ["--all", "5"]);
+    expect(fetchCalls[0].url).toBe("/api/wormhole/session");
+    expect(fetchCalls[1].url).toBe("/api/wormhole/request");
+    expect(result.output).toBe("ok");
+    expect(result.trust_tier).toBe("readonly");
+  });
+
+  test("request() POSTs the correct body shape", async () => {
+    mockFetch((url) => {
+      if (url === "/api/wormhole/session") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ output: "ok", from: "w", elapsed_ms: 1, status: 200, trust_tier: "readonly" }),
+        { status: 200 },
+      );
+    });
+    const wh = new WormholeClient("white", "local.example.com");
+    await wh.request("/dig", ["--all", "5"]);
+    const postCall = fetchCalls[1];
+    expect(postCall.init?.method).toBe("POST");
+    const body = JSON.parse(postCall.init!.body as string);
+    expect(body.peer).toBe("white");
+    expect(body.cmd).toBe("/dig");
+    expect(body.args).toEqual(["--all", "5"]);
+    expect(body.signature).toMatch(/^\[local\.example\.com:anon-/);
+  });
+
+  test("request() defaults args to [] when not provided", async () => {
+    mockFetch((url) => {
+      if (url === "/api/wormhole/session") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ output: "ok", from: "w", elapsed_ms: 1, status: 200, trust_tier: "readonly" }),
+        { status: 200 },
+      );
+    });
+    const wh = new WormholeClient("white", "local.example.com");
+    await wh.request("/dig");
+    const body = JSON.parse(fetchCalls[1].init!.body as string);
+    expect(body.args).toEqual([]);
+  });
+
+  test("request() uses same-origin credentials", async () => {
+    mockFetch(() =>
+      new Response(
+        JSON.stringify({ output: "ok", from: "w", elapsed_ms: 1, status: 200, trust_tier: "readonly" }),
+        { status: 200 },
+      ),
+    );
+    const wh = new WormholeClient("white", "local.example.com");
+    await wh.ensureSession();
+    await wh.request("/dig");
+    expect(fetchCalls[0].init?.credentials).toBe("same-origin");
+    expect(fetchCalls[1].init?.credentials).toBe("same-origin");
+  });
+
+  test("request() throws typed error with .status and .body on non-2xx", async () => {
+    mockFetch((url) => {
+      if (url === "/api/wormhole/session") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({ error: "shell_peer_denied", hint: "anon is read-only" }),
+        { status: 403 },
+      );
+    });
+    const wh = new WormholeClient("white", "local.example.com");
+    try {
+      await wh.request("/awaken");
+      expect.unreachable("should have thrown");
+    } catch (err: any) {
+      expect(err.message).toContain("wormhole: 403");
+      expect(err.message).toContain("shell_peer_denied");
+      expect(err.status).toBe(403);
+      expect(err.body.error).toBe("shell_peer_denied");
+    }
+  });
+
+  test("request() returns a typed WormholeResponse on success", async () => {
+    mockFetch((url) => {
+      if (url === "/api/wormhole/session") {
+        return new Response(JSON.stringify({ ok: true }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({
+          output: "dig output here",
+          from: "http://10.20.0.7:3456",
+          elapsed_ms: 123,
+          status: 200,
+          trust_tier: "readonly",
+        }),
+        { status: 200 },
+      );
+    });
+    const wh = new WormholeClient("white", "local.example.com");
+    const result: WormholeResponse = await wh.request("/dig");
+    expect(result.output).toBe("dig output here");
+    expect(result.from).toBe("http://10.20.0.7:3456");
+    expect(result.elapsed_ms).toBe(123);
+    expect(result.status).toBe(200);
+    expect(result.trust_tier).toBe("readonly");
+  });
+});

--- a/src/lib/wormholeClient.ts
+++ b/src/lib/wormholeClient.ts
@@ -1,0 +1,197 @@
+/**
+ * WormholeClient — browser-side client for POST /api/wormhole/request.
+ *
+ * PROTOTYPE — iteration 3 of the federation-join-easy proof. See
+ * `mawui-oracle/ψ/writing/federation-join-easy.md` for full context. Companion
+ * to `maw-js/src/api/wormhole.ts` (the server half drafted in parallel on
+ * maw-js's feat/wormhole-http-endpoint-draft branch).
+ *
+ * ## Why this client exists
+ *
+ * `src/lib/api.ts` implements the drizzle.studio `?host=` pattern and works
+ * perfectly for HTTPS peers. But the "lazy-setup federation via global UI"
+ * case hits three walls for HTTP-LAN / WireGuard-only peers:
+ *
+ *   1. Mixed-content rule blocks HTTPS origin → HTTP peer fetches
+ *   2. WireGuard-only peers aren't reachable from the browser at all
+ *   3. Browsers don't know `federationToken` and shouldn't
+ *
+ * The WormholeClient bypasses all three by relaying through the local
+ * maw-js backend. It's same-origin (no mixed content), the backend has
+ * WG routes (peer reachability), and the backend signs with HMAC (no
+ * secret in the browser).
+ *
+ * ## Signature shape
+ *
+ * Anonymous browser visitors carry `[<host>:anon-<nonce>]`. The backend's
+ * trust boundary treats any `anon-*` origin as permanently read-only —
+ * it's never on `config.wormhole.shellPeers`. This means a drive-by visitor
+ * to the hosted UI can run `/dig`, `/trace`, `/recap`, `/standup`, and other
+ * readonly commands against any peer, but can never mutate state on a
+ * federation they don't own.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { WormholeClient } from "./wormholeClient";
+ *
+ * const hostParam = new URLSearchParams(location.search).get("host");
+ * const wh = new WormholeClient(hostParam ?? "localhost");
+ * await wh.ensureSession(); // once, on page load
+ *
+ * const result = await wh.request("/dig", ["--all", "5"]);
+ * console.log(result.output);
+ * ```
+ *
+ * ## Coexistence with apiUrl()
+ *
+ * `src/lib/api.ts`'s `apiUrl()` helper is NOT replaced by this client. The
+ * two coexist:
+ *
+ *   - `apiUrl()` = direct-fetch path, works for HTTPS peers, no backend relay
+ *   - `WormholeClient` = relay path, needed for HTTP-LAN / WG-only peers
+ *
+ * The UI can pick at runtime based on the `?host=` form: if the resolved
+ * peer URL is HTTPS, use `apiUrl()`; if it's HTTP or a bare peer name, use
+ * `WormholeClient`. Iteration 4 will add a tiny dispatcher helper for this.
+ *
+ * ## Status
+ *
+ * - **Iteration 3 prototype** — drafted on `feat/wormhole-client-draft` branch,
+ *   NOT merged to main, NOT part of a PR yet.
+ * - No call-site migration in this iteration — just the client class.
+ * - Awaits server half in maw-js + Nat's confirmation on deploy ownership.
+ */
+
+// --- Types ---------------------------------------------------------------
+
+export interface WormholeResponse {
+  /** The peer's raw response body */
+  output: string;
+  /** Which peer URL served the response */
+  from: string;
+  /** Round-trip time including backend relay + peer execution */
+  elapsed_ms: number;
+  /** Upstream HTTP status from the peer */
+  status: number;
+  /** Trust tier the backend applied: "readonly" or "shell_allowlisted" */
+  trust_tier: "readonly" | "shell_allowlisted";
+}
+
+export interface WormholeError {
+  error: string;
+  [key: string]: unknown;
+}
+
+// --- Signature generation ------------------------------------------------
+
+/**
+ * Generate an anonymous signature for a browser visitor. Uses crypto.randomUUID()
+ * if available (modern browsers), else falls back to Math.random.
+ *
+ * The nonce is 8 hex chars — enough for uniqueness within a session but not
+ * so long that logs become unreadable.
+ */
+export function generateAnonSignature(originHost: string): string {
+  let nonce: string;
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    nonce = crypto.randomUUID().replace(/-/g, "").slice(0, 8);
+  } else {
+    nonce = Math.random().toString(16).slice(2, 10).padEnd(8, "0");
+  }
+  return `[${originHost}:anon-${nonce}]`;
+}
+
+// --- Client --------------------------------------------------------------
+
+export class WormholeClient {
+  readonly peer: string;
+  readonly signature: string;
+  private sessionReady = false;
+
+  constructor(peer: string, originHost?: string) {
+    this.peer = peer;
+    // Default origin: the current window's host (hostname + optional :port).
+    // Guards for SSR / test environments where `window` is undefined.
+    const host =
+      originHost ??
+      (typeof window !== "undefined" ? window.location.host : "unknown-origin");
+    this.signature = generateAnonSignature(host);
+  }
+
+  /**
+   * Fetch the wormhole session cookie. MUST be called once before any
+   * `request()` calls in production. Safe to call multiple times — the
+   * backend re-issues the same cookie on each GET.
+   *
+   * Idempotent: subsequent calls short-circuit after the first success.
+   */
+  async ensureSession(): Promise<void> {
+    if (this.sessionReady) return;
+    const res = await fetch("/api/wormhole/session", {
+      credentials: "same-origin",
+    });
+    if (!res.ok) {
+      throw new Error(
+        `wormhole: session bootstrap failed (${res.status} ${res.statusText})`,
+      );
+    }
+    this.sessionReady = true;
+  }
+
+  /**
+   * Relay a command to the configured peer. Readonly commands
+   * (/dig, /trace, /recap, /standup, /who-are-you, /philosophy,
+   * /where-we-are) work for anonymous visitors; other commands will 403
+   * unless the backend has this origin in config.wormhole.shellPeers.
+   */
+  async request(cmd: string, args: string[] = []): Promise<WormholeResponse> {
+    if (!this.sessionReady) {
+      // Auto-bootstrap — easier for callers who forget.
+      await this.ensureSession();
+    }
+
+    const res = await fetch("/api/wormhole/request", {
+      method: "POST",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        peer: this.peer,
+        cmd,
+        args,
+        signature: this.signature,
+      }),
+    });
+
+    if (!res.ok) {
+      const body = (await res.json().catch(() => ({}))) as WormholeError;
+      const err = new Error(
+        `wormhole: ${res.status} ${body.error ?? res.statusText} (peer=${this.peer}, cmd=${cmd})`,
+      );
+      (err as any).status = res.status;
+      (err as any).body = body;
+      throw err;
+    }
+
+    return (await res.json()) as WormholeResponse;
+  }
+
+  /**
+   * Convenience: is this cmd safe to run anonymously? Mirrors the backend
+   * trust boundary. Useful for UI gating — disable a button before the
+   * backend would 403.
+   */
+  static isReadOnlyCmd(cmd: string): boolean {
+    const READONLY = [
+      "/dig",
+      "/trace",
+      "/recap",
+      "/standup",
+      "/who-are-you",
+      "/philosophy",
+      "/where-we-are",
+    ];
+    const trimmed = cmd.trim();
+    return READONLY.some((prefix) => trimmed === prefix || trimmed.startsWith(prefix + " "));
+  }
+}


### PR DESCRIPTION
## Draft — federation-join-easy client helpers

4 pure helper modules for the federation-join-easy pattern:

1. **WormholeClient** (197 LOC, 35 tests) — browser client for POST /api/wormhole/request
2. **peerConnection** (193 LOC, 25 tests) — classify ?host= into 4 kinds: same-origin / direct / mixed-content-blocked / invalid
3. **PeerProxyClient** (250 LOC, 32 tests) — browser client for POST /api/proxy
4. **peerConnectionBanner** (172 LOC, 24 tests) — derive UI error banner from the 4-kind classification

Total: 1,881 LOC, 116 tests all green.

Cross-repo invariant locks: server + client whitelists locked to the SAME verbs/methods in both test files.

See mawui-oracle/ψ/writing/federation-join-easy.md for full context.

🤖 Co-authored by mawui-oracle