### PR TITLE
refactor: rename WormholeClient → PeerExecClient

### DIFF
--- a/src/lib/peerConnection.ts
+++ b/src/lib/peerConnection.ts
@@ -10,12 +10,12 @@
  * ## The shape confusion this helper closes
  *
  * Iterations 1-4 framed a "runtime dispatcher" that would pick between
- * `apiUrl()` (direct fetch) and `WormholeClient` (relay) based on peer shape.
+ * `apiUrl()` (direct fetch) and `PeerExecClient` (relay) based on peer shape.
  * **That framing was wrong** — the two primitives serve DIFFERENT needs:
  *
  *   - `apiUrl()` is for **REST data fetching** — `/api/config`, `/api/feed`,
  *     `/api/sessions`, etc. Arbitrary HTTP GET/POST against a peer's API.
- *   - `WormholeClient` is for **signed command execution** — `/dig`,
+ *   - `PeerExecClient` is for **signed command execution** — `/dig`,
  *     `/trace`, `/recap`. RPC-shaped, readonly-or-allowlisted, returns a
  *     command output string.
  *
@@ -220,7 +220,7 @@ export function resolvePeerConnection(
  * `mixed-content-blocked` and `invalid`.
  *
  * Useful for gating UI elements that depend on arbitrary REST reads.
- * For command execution, use `WormholeClient` instead regardless of
+ * For command execution, use `PeerExecClient` instead regardless of
  * this helper's result.
  */
 export function canFetchDirectly(

--- a/src/lib/peerConnectionBanner.ts
+++ b/src/lib/peerConnectionBanner.ts
@@ -117,7 +117,7 @@ export function getPeerConnectionBanner(pc: PeerConnection): PeerConnectionBanne
           {
             label: "Use /wormhole for commands",
             description:
-              "POST /api/wormhole/request on your local backend relays signed commands " +
+              "POST /api/peer/exec on your local backend relays signed commands " +
               "(/dig, /trace, /recap) to any peer. NOT for arbitrary REST reads.",
           },
         ],

--- a/src/lib/peerExecClient.test.ts
+++ b/src/lib/peerExecClient.test.ts
@@ -1,24 +1,24 @@
 /**
- * Tests for WormholeClient — browser-side client for POST /api/wormhole/request.
- * Companion to src/lib/wormholeClient.ts and maw-js/test/wormhole.test.ts.
+ * Tests for PeerExecClient — browser-side client for POST /api/peer/exec.
+ * Companion to src/lib/peerExecClient.ts and maw-js/test/wormhole.test.ts.
  *
  * PROTOTYPE — iteration 4 of the federation-join-easy /loop, drafted on the
  * feat/wormhole-client-draft branch. See
  * mawui-oracle/ψ/writing/federation-join-easy.md for context.
  *
  * maw-ui has no explicit test runner in package.json (only vite scripts), but
- * `bun test` works natively on `.test.ts` files and the WormholeClient has no
+ * `bun test` works natively on `.test.ts` files and the PeerExecClient has no
  * React/DOM/vite dependencies beyond `fetch` and `crypto.randomUUID` which are
- * both globals in modern bun. Runs via: `bun test src/lib/wormholeClient.test.ts`
+ * both globals in modern bun. Runs via: `bun test src/lib/peerExecClient.test.ts`
  * from the maw-ui repo root.
  */
 
 import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
 import {
-  WormholeClient,
+  PeerExecClient,
   generateAnonSignature,
-  type WormholeResponse,
-} from "./wormholeClient";
+  type PeerExecResponse,
+} from "./peerExecClient";
 
 // ---- Pure helper tests ---------------------------------------------------
 
@@ -51,7 +51,7 @@ describe("generateAnonSignature", () => {
   });
 });
 
-describe("WormholeClient.isReadOnlyCmd (static helper)", () => {
+describe("PeerExecClient.isReadOnlyCmd (static helper)", () => {
   test.each([
     "/dig",
     "/dig --all 5",
@@ -63,7 +63,7 @@ describe("WormholeClient.isReadOnlyCmd (static helper)", () => {
     "/philosophy",
     "/where-we-are",
   ])("permits %s", (cmd) => {
-    expect(WormholeClient.isReadOnlyCmd(cmd)).toBe(true);
+    expect(PeerExecClient.isReadOnlyCmd(cmd)).toBe(true);
   });
 
   test.each([
@@ -75,7 +75,7 @@ describe("WormholeClient.isReadOnlyCmd (static helper)", () => {
     "dig",
     "",
   ])("denies %s", (cmd) => {
-    expect(WormholeClient.isReadOnlyCmd(cmd)).toBe(false);
+    expect(PeerExecClient.isReadOnlyCmd(cmd)).toBe(false);
   });
 
   test("mirrors the server-side whitelist (same 7 verbs)", () => {
@@ -91,30 +91,30 @@ describe("WormholeClient.isReadOnlyCmd (static helper)", () => {
       "/where-we-are",
     ];
     for (const verb of SERVER_WHITELIST) {
-      expect(WormholeClient.isReadOnlyCmd(verb)).toBe(true);
+      expect(PeerExecClient.isReadOnlyCmd(verb)).toBe(true);
     }
   });
 });
 
-// ---- WormholeClient class tests ------------------------------------------
+// ---- PeerExecClient class tests ------------------------------------------
 
-describe("WormholeClient — construction", () => {
+describe("PeerExecClient — construction", () => {
   test("stores peer + generates anon signature at construction", () => {
-    const wh = new WormholeClient("white", "local.example.com");
-    expect(wh.peer).toBe("white");
-    expect(wh.signature).toMatch(/^\[local\.example\.com:anon-[a-f0-9]{8}\]$/);
+    const pe = new PeerExecClient("white", "local.example.com");
+    expect(pe.peer).toBe("white");
+    expect(pe.signature).toMatch(/^\[local\.example\.com:anon-[a-f0-9]{8}\]$/);
   });
 
   test("signature is stable for the lifetime of one instance", () => {
-    const wh = new WormholeClient("white", "local.example.com");
-    const sig1 = wh.signature;
-    const sig2 = wh.signature;
+    const pe = new PeerExecClient("white", "local.example.com");
+    const sig1 = pe.signature;
+    const sig2 = pe.signature;
     expect(sig1).toBe(sig2);
   });
 
   test("two instances produce different signatures", () => {
-    const a = new WormholeClient("white", "local.example.com");
-    const b = new WormholeClient("white", "local.example.com");
+    const a = new PeerExecClient("white", "local.example.com");
+    const b = new PeerExecClient("white", "local.example.com");
     expect(a.signature).not.toBe(b.signature);
   });
 
@@ -122,8 +122,8 @@ describe("WormholeClient — construction", () => {
     // Stub a minimal window object
     (globalThis as any).window = { location: { host: "stubbed.example.com" } };
     try {
-      const wh = new WormholeClient("white");
-      expect(wh.signature.startsWith("[stubbed.example.com:anon-")).toBe(true);
+      const pe = new PeerExecClient("white");
+      expect(pe.signature.startsWith("[stubbed.example.com:anon-")).toBe(true);
     } finally {
       delete (globalThis as any).window;
     }
@@ -132,14 +132,14 @@ describe("WormholeClient — construction", () => {
   test("falls back to 'unknown-origin' in non-browser environments", () => {
     // Ensure no window object
     delete (globalThis as any).window;
-    const wh = new WormholeClient("white");
-    expect(wh.signature.startsWith("[unknown-origin:anon-")).toBe(true);
+    const pe = new PeerExecClient("white");
+    expect(pe.signature.startsWith("[unknown-origin:anon-")).toBe(true);
   });
 });
 
 // ---- fetch mocking -------------------------------------------------------
 
-describe("WormholeClient — fetch interactions", () => {
+describe("PeerExecClient — fetch interactions", () => {
   let originalFetch: typeof fetch;
   let fetchCalls: Array<{ url: string; init?: RequestInit }>;
 
@@ -160,32 +160,32 @@ describe("WormholeClient — fetch interactions", () => {
     }) as typeof fetch;
   }
 
-  test("ensureSession() GETs /api/wormhole/session", async () => {
+  test("ensureSession() GETs /api/peer/session", async () => {
     mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
-    const wh = new WormholeClient("white", "local.example.com");
-    await wh.ensureSession();
+    const pe = new PeerExecClient("white", "local.example.com");
+    await pe.ensureSession();
     expect(fetchCalls.length).toBe(1);
-    expect(fetchCalls[0].url).toBe("/api/wormhole/session");
+    expect(fetchCalls[0].url).toBe("/api/peer/session");
   });
 
   test("ensureSession() is idempotent (multiple calls → one fetch)", async () => {
     mockFetch(() => new Response(JSON.stringify({ ok: true }), { status: 200 }));
-    const wh = new WormholeClient("white", "local.example.com");
-    await wh.ensureSession();
-    await wh.ensureSession();
-    await wh.ensureSession();
+    const pe = new PeerExecClient("white", "local.example.com");
+    await pe.ensureSession();
+    await pe.ensureSession();
+    await pe.ensureSession();
     expect(fetchCalls.length).toBe(1);
   });
 
   test("ensureSession() throws on non-2xx response", async () => {
     mockFetch(() => new Response("forbidden", { status: 403 }));
-    const wh = new WormholeClient("white", "local.example.com");
-    await expect(wh.ensureSession()).rejects.toThrow(/session bootstrap failed.*403/);
+    const pe = new PeerExecClient("white", "local.example.com");
+    await expect(pe.ensureSession()).rejects.toThrow(/session bootstrap failed.*403/);
   });
 
   test("request() auto-bootstraps session if caller forgets", async () => {
     mockFetch((url) => {
-      if (url === "/api/wormhole/session") {
+      if (url === "/api/peer/session") {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return new Response(
@@ -193,17 +193,17 @@ describe("WormholeClient — fetch interactions", () => {
         { status: 200 },
       );
     });
-    const wh = new WormholeClient("white", "local.example.com");
-    const result = await wh.request("/dig", ["--all", "5"]);
-    expect(fetchCalls[0].url).toBe("/api/wormhole/session");
-    expect(fetchCalls[1].url).toBe("/api/wormhole/request");
+    const pe = new PeerExecClient("white", "local.example.com");
+    const result = await pe.request("/dig", ["--all", "5"]);
+    expect(fetchCalls[0].url).toBe("/api/peer/session");
+    expect(fetchCalls[1].url).toBe("/api/peer/exec");
     expect(result.output).toBe("ok");
     expect(result.trust_tier).toBe("readonly");
   });
 
   test("request() POSTs the correct body shape", async () => {
     mockFetch((url) => {
-      if (url === "/api/wormhole/session") {
+      if (url === "/api/peer/session") {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return new Response(
@@ -211,8 +211,8 @@ describe("WormholeClient — fetch interactions", () => {
         { status: 200 },
       );
     });
-    const wh = new WormholeClient("white", "local.example.com");
-    await wh.request("/dig", ["--all", "5"]);
+    const pe = new PeerExecClient("white", "local.example.com");
+    await pe.request("/dig", ["--all", "5"]);
     const postCall = fetchCalls[1];
     expect(postCall.init?.method).toBe("POST");
     const body = JSON.parse(postCall.init!.body as string);
@@ -224,7 +224,7 @@ describe("WormholeClient — fetch interactions", () => {
 
   test("request() defaults args to [] when not provided", async () => {
     mockFetch((url) => {
-      if (url === "/api/wormhole/session") {
+      if (url === "/api/peer/session") {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return new Response(
@@ -232,8 +232,8 @@ describe("WormholeClient — fetch interactions", () => {
         { status: 200 },
       );
     });
-    const wh = new WormholeClient("white", "local.example.com");
-    await wh.request("/dig");
+    const pe = new PeerExecClient("white", "local.example.com");
+    await pe.request("/dig");
     const body = JSON.parse(fetchCalls[1].init!.body as string);
     expect(body.args).toEqual([]);
   });
@@ -245,16 +245,16 @@ describe("WormholeClient — fetch interactions", () => {
         { status: 200 },
       ),
     );
-    const wh = new WormholeClient("white", "local.example.com");
-    await wh.ensureSession();
-    await wh.request("/dig");
+    const pe = new PeerExecClient("white", "local.example.com");
+    await pe.ensureSession();
+    await pe.request("/dig");
     expect(fetchCalls[0].init?.credentials).toBe("same-origin");
     expect(fetchCalls[1].init?.credentials).toBe("same-origin");
   });
 
   test("request() throws typed error with .status and .body on non-2xx", async () => {
     mockFetch((url) => {
-      if (url === "/api/wormhole/session") {
+      if (url === "/api/peer/session") {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return new Response(
@@ -262,21 +262,21 @@ describe("WormholeClient — fetch interactions", () => {
         { status: 403 },
       );
     });
-    const wh = new WormholeClient("white", "local.example.com");
+    const pe = new PeerExecClient("white", "local.example.com");
     try {
-      await wh.request("/awaken");
+      await pe.request("/awaken");
       expect.unreachable("should have thrown");
     } catch (err: any) {
-      expect(err.message).toContain("wormhole: 403");
+      expect(err.message).toContain("peerExec: 403");
       expect(err.message).toContain("shell_peer_denied");
       expect(err.status).toBe(403);
       expect(err.body.error).toBe("shell_peer_denied");
     }
   });
 
-  test("request() returns a typed WormholeResponse on success", async () => {
+  test("request() returns a typed PeerExecResponse on success", async () => {
     mockFetch((url) => {
-      if (url === "/api/wormhole/session") {
+      if (url === "/api/peer/session") {
         return new Response(JSON.stringify({ ok: true }), { status: 200 });
       }
       return new Response(
@@ -290,8 +290,8 @@ describe("WormholeClient — fetch interactions", () => {
         { status: 200 },
       );
     });
-    const wh = new WormholeClient("white", "local.example.com");
-    const result: WormholeResponse = await wh.request("/dig");
+    const pe = new PeerExecClient("white", "local.example.com");
+    const result: PeerExecResponse = await pe.request("/dig");
     expect(result.output).toBe("dig output here");
     expect(result.from).toBe("http://10.20.0.7:3456");
     expect(result.elapsed_ms).toBe(123);

--- a/src/lib/peerExecClient.ts
+++ b/src/lib/peerExecClient.ts
@@ -1,5 +1,5 @@
 /**
- * WormholeClient — browser-side client for POST /api/wormhole/request.
+ * PeerExecClient — browser-side client for POST /api/peer/exec.
  *
  * PROTOTYPE — iteration 3 of the federation-join-easy proof. See
  * `mawui-oracle/ψ/writing/federation-join-easy.md` for full context. Companion
@@ -16,7 +16,7 @@
  *   2. WireGuard-only peers aren't reachable from the browser at all
  *   3. Browsers don't know `federationToken` and shouldn't
  *
- * The WormholeClient bypasses all three by relaying through the local
+ * The PeerExecClient bypasses all three by relaying through the local
  * maw-js backend. It's same-origin (no mixed content), the backend has
  * WG routes (peer reachability), and the backend signs with HMAC (no
  * secret in the browser).
@@ -33,13 +33,13 @@
  * ## Usage
  *
  * ```ts
- * import { WormholeClient } from "./wormholeClient";
+ * import { PeerExecClient } from "./peerExecClient";
  *
  * const hostParam = new URLSearchParams(location.search).get("host");
- * const wh = new WormholeClient(hostParam ?? "localhost");
- * await wh.ensureSession(); // once, on page load
+ * const pe = new PeerExecClient(hostParam ?? "localhost");
+ * await pe.ensureSession(); // once, on page load
  *
- * const result = await wh.request("/dig", ["--all", "5"]);
+ * const result = await pe.request("/dig", ["--all", "5"]);
  * console.log(result.output);
  * ```
  *
@@ -49,11 +49,11 @@
  * two coexist:
  *
  *   - `apiUrl()` = direct-fetch path, works for HTTPS peers, no backend relay
- *   - `WormholeClient` = relay path, needed for HTTP-LAN / WG-only peers
+ *   - `PeerExecClient` = relay path, needed for HTTP-LAN / WG-only peers
  *
  * The UI can pick at runtime based on the `?host=` form: if the resolved
  * peer URL is HTTPS, use `apiUrl()`; if it's HTTP or a bare peer name, use
- * `WormholeClient`. Iteration 4 will add a tiny dispatcher helper for this.
+ * `PeerExecClient`. Iteration 4 will add a tiny dispatcher helper for this.
  *
  * ## Status
  *
@@ -65,7 +65,7 @@
 
 // --- Types ---------------------------------------------------------------
 
-export interface WormholeResponse {
+export interface PeerExecResponse {
   /** The peer's raw response body */
   output: string;
   /** Which peer URL served the response */
@@ -78,7 +78,7 @@ export interface WormholeResponse {
   trust_tier: "readonly" | "shell_allowlisted";
 }
 
-export interface WormholeError {
+export interface PeerExecError {
   error: string;
   [key: string]: unknown;
 }
@@ -104,7 +104,7 @@ export function generateAnonSignature(originHost: string): string {
 
 // --- Client --------------------------------------------------------------
 
-export class WormholeClient {
+export class PeerExecClient {
   readonly peer: string;
   readonly signature: string;
   private sessionReady = false;
@@ -120,7 +120,7 @@ export class WormholeClient {
   }
 
   /**
-   * Fetch the wormhole session cookie. MUST be called once before any
+   * Fetch the peer-exec session cookie. MUST be called once before any
    * `request()` calls in production. Safe to call multiple times — the
    * backend re-issues the same cookie on each GET.
    *
@@ -128,12 +128,12 @@ export class WormholeClient {
    */
   async ensureSession(): Promise<void> {
     if (this.sessionReady) return;
-    const res = await fetch("/api/wormhole/session", {
+    const res = await fetch("/api/peer/session", {
       credentials: "same-origin",
     });
     if (!res.ok) {
       throw new Error(
-        `wormhole: session bootstrap failed (${res.status} ${res.statusText})`,
+        `peerExec: session bootstrap failed (${res.status} ${res.statusText})`,
       );
     }
     this.sessionReady = true;
@@ -145,13 +145,13 @@ export class WormholeClient {
    * /where-we-are) work for anonymous visitors; other commands will 403
    * unless the backend has this origin in config.wormhole.shellPeers.
    */
-  async request(cmd: string, args: string[] = []): Promise<WormholeResponse> {
+  async request(cmd: string, args: string[] = []): Promise<PeerExecResponse> {
     if (!this.sessionReady) {
       // Auto-bootstrap — easier for callers who forget.
       await this.ensureSession();
     }
 
-    const res = await fetch("/api/wormhole/request", {
+    const res = await fetch("/api/peer/exec", {
       method: "POST",
       credentials: "same-origin",
       headers: { "Content-Type": "application/json" },
@@ -164,16 +164,16 @@ export class WormholeClient {
     });
 
     if (!res.ok) {
-      const body = (await res.json().catch(() => ({}))) as WormholeError;
+      const body = (await res.json().catch(() => ({}))) as PeerExecError;
       const err = new Error(
-        `wormhole: ${res.status} ${body.error ?? res.statusText} (peer=${this.peer}, cmd=${cmd})`,
+        `peerExec: ${res.status} ${body.error ?? res.statusText} (peer=${this.peer}, cmd=${cmd})`,
       );
       (err as any).status = res.status;
       (err as any).body = body;
       throw err;
     }
 
-    return (await res.json()) as WormholeResponse;
+    return (await res.json()) as PeerExecResponse;
   }
 
   /**

--- a/src/lib/peerProxyClient.test.ts
+++ b/src/lib/peerProxyClient.test.ts
@@ -5,7 +5,7 @@
  * feat/wormhole-client-draft. See
  * mawui-oracle/ψ/writing/federation-join-easy.md for context.
  *
- * Mirrors wormholeClient.test.ts conventions — pure helpers, construction,
+ * Mirrors peerExecClient.test.ts conventions — pure helpers, construction,
  * async fetch interactions via globalThis.fetch mock swap. Locks the
  * load-bearing invariant that GET/HEAD/OPTIONS are readonly and that the
  * client surfaces typed errors with .status + .body.

--- a/src/lib/peerProxyClient.ts
+++ b/src/lib/peerProxyClient.ts
@@ -2,7 +2,7 @@
  * PeerProxyClient — browser-side client for `POST /api/proxy`.
  *
  * PROTOTYPE — iteration 7 of the federation-join-easy /loop. Drafted on the
- * `feat/wormhole-client-draft` branch (alongside `WormholeClient` and
+ * `feat/wormhole-client-draft` branch (alongside `PeerExecClient` and
  * `peerConnection`). See
  * `mawui-oracle/ψ/writing/federation-join-easy.md` for full context.
  *
@@ -10,9 +10,9 @@
  *
  * This client pairs with `maw-js/src/api/proxy.ts` (server-side, drafted on
  * `feat/api-proxy-http-peers`). It is a SEPARATE client from
- * `wormholeClient.ts` because it serves a different need:
+ * `peerExecClient.ts` because it serves a different need:
  *
- *   - **`WormholeClient`** — signed command execution (`/dig`, `/trace`,
+ *   - **`PeerExecClient`** — signed command execution (`/dig`, `/trace`,
  *     `/recap`). RPC-shaped. Returns command output strings.
  *   - **`PeerProxyClient`** — generic HTTP REST relay. Returns full HTTP
  *     responses (status, headers, body). Used when an HTTPS origin needs
@@ -46,7 +46,7 @@
  *
  * - Iteration 7 prototype, on `feat/wormhole-client-draft` (the maw-ui
  *   federation bundle branch). PR-time decision: split into separate PRs
- *   for peerConnection / WormholeClient / PeerProxyClient, or ship as one.
+ *   for peerConnection / PeerExecClient / PeerProxyClient, or ship as one.
  * - Companion server endpoint `POST /api/proxy` lives on the SEPARATE
  *   `feat/api-proxy-http-peers` branch on maw-js. Both will be filed
  *   together when Q#5 (deploy ownership) is answered.
@@ -80,7 +80,7 @@ export interface PeerProxyError {
 
 /**
  * Generate an anonymous signature for a browser visitor. Same shape as
- * `generateAnonSignature` in `wormholeClient.ts` — duplicated here to avoid
+ * `generateAnonSignature` in `peerExecClient.ts` — duplicated here to avoid
  * cross-file coupling between two prototype clients. If we ever share this,
  * it moves to `src/lib/signature.ts` with explicit dual-consumer tests.
  */


### PR DESCRIPTION
Companion to maw-js rename PR. Mechanical, zero logic changes. Nat + mawjs-oracle approved direction.

## What changed

| Before | After |
|--------|-------|
| `WormholeClient` | `PeerExecClient` |
| `WormholeResponse` | `PeerExecResponse` |
| `WormholeError` | `PeerExecError` |
| `wormholeClient.ts` | `peerExecClient.ts` |
| `/api/wormhole/session` | `/api/peer/session` |
| `/api/wormhole/request` | `/api/peer/exec` |
| `"wormhole: "` error prefix | `"peerExec: "` error prefix |

Internal `/wormhole` skill name unchanged — this is ONLY the client code.

## Files touched

- `src/lib/peerExecClient.ts` (renamed from `wormholeClient.ts`)
- `src/lib/peerExecClient.test.ts` (renamed from `wormholeClient.test.ts`)
- `src/lib/peerConnectionBanner.ts` (endpoint path in action description)
- `src/lib/peerConnection.ts` (class name references in comments)
- `src/lib/peerProxyClient.ts` (class/file name references in comments)
- `src/lib/peerProxyClient.test.ts` (file name reference in comment)

## Test plan

- [x] `npx vite build` — passes
- [x] `bun test src/lib/peerExecClient.test.ts` — 35/35 pass
- [x] `bun test src/lib/peerConnectionBanner.test.ts` — 24/24 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)