### PR TITLE
fix(ux): XTerminal sticky-bottom scroll — mobile #27

### DIFF
--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -78,8 +78,14 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
           </div>
         </div>
 
-        {/* Terminal — xterm.js via PTY WebSocket */}
-        <div className="flex-1 overflow-hidden">
+        {/* Terminal — xterm.js via PTY WebSocket.
+            touchAction:pan-y + overscrollBehavior:contain let iOS forward
+            vertical touch into xterm's viewport (so user can scroll up)
+            while blocking pull-to-refresh and bubbling to body. (#27) */}
+        <div
+          className="flex-1 overflow-hidden"
+          style={{ touchAction: "pan-y", overscrollBehavior: "contain" }}
+        >
           <Suspense fallback={
             <div className="flex items-center justify-center h-full text-white/30 text-sm font-mono">
               Loading terminal...

--- a/src/components/XTerminal.tsx
+++ b/src/components/XTerminal.tsx
@@ -39,6 +39,13 @@ const THEME = {
   brightWhite: "#ffffff",
 };
 
+// Sticky-bottom scroll (#27 mobile path): preserve user scroll position when
+// new PTY output arrives. xterm.js auto-scrolls to follow the cursor on every
+// write() — without this, scrolling up to read history snaps back down on the
+// next "thinking dots" tick. Threshold of 5 lines absorbs fit.fit() jitter on
+// resize (keyboard open/close, orientation change).
+const STICKY_THRESHOLD_LINES = 5;
+
 export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibling, readOnly = false }: XTerminalProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -47,6 +54,8 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
   const onNavigateRef = useRef(onNavigate);
   const siblingsRef = useRef(siblings);
   const onSelectSiblingRef = useRef(onSelectSibling);
+  // Tracks whether the user scrolled up past the threshold; set by term.onScroll.
+  const wasScrolledUpRef = useRef(false);
   useEffect(() => { onCloseRef.current = onClose; }, [onClose]);
   useEffect(() => { onNavigateRef.current = onNavigate; }, [onNavigate]);
   useEffect(() => { siblingsRef.current = siblings; }, [siblings]);
@@ -64,10 +73,31 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
       cursorBlink: !readOnly,
       cursorStyle: readOnly ? "underline" : "bar",
       disableStdin: readOnly,
+      scrollback: 10000,
     });
 
     const fit = new FitAddon();
     term.loadAddon(fit);
+
+    // Track whether the user has scrolled up — writeWithStickyBottom uses this
+    // to decide whether to counter-scroll after each write.
+    term.onScroll(() => {
+      const buf = term.buffer.active;
+      wasScrolledUpRef.current = (buf.baseY - buf.viewportY) > STICKY_THRESHOLD_LINES;
+    });
+
+    // Wrapper around term.write that preserves user scroll position. xterm
+    // always follows the cursor on write; this measures how many lines
+    // baseY advanced and counter-scrolls by the same delta via the write
+    // callback (runs after parse, when the new baseY is final).
+    const writeWithStickyBottom = (data: Uint8Array | string) => {
+      const preBaseY = term.buffer.active.baseY;
+      term.write(data, () => {
+        if (!wasScrolledUpRef.current) return;
+        const delta = term.buffer.active.baseY - preBaseY;
+        if (delta > 0) term.scrollLines(-delta);
+      });
+    };
 
     let ws: WebSocket | null = null;
     let dataSub: { dispose: () => void } | null = null;
@@ -105,17 +135,17 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
               try { fit.fit(); } catch {}
             }
             if (msg.type === "detached") {
-              term.write("\r\n\x1b[33m[session detached]\x1b[0m\r\n");
+              writeWithStickyBottom("\r\n\x1b[33m[session detached]\x1b[0m\r\n");
             }
           } catch {}
         } else {
           // Binary PTY data → render in xterm.js
-          term.write(new Uint8Array(e.data));
+          writeWithStickyBottom(new Uint8Array(e.data));
         }
       };
 
       ws.onclose = () => {
-        term.write("\r\n\x1b[31m[connection closed]\x1b[0m\r\n");
+        writeWithStickyBottom("\r\n\x1b[31m[connection closed]\x1b[0m\r\n");
       };
 
       if (!readOnly) {


### PR DESCRIPTION
## Summary

- Mobile path (TerminalModal → XTerminal/xterm.js) auto-scrolled to bottom on every PTY write even when user scrolled up — thinking dots snapped view back instantly
- Root cause: XTerminal.tsx had ZERO scroll config; prior PR#28 only fixed desktop HoverPreviewCard path; mobile commit 189d651 routes touch → xterm.js directly
- `writeWithStickyBottom` wrapper preserves user scroll position via `term.onScroll` tracker + post-write counter-scroll

## Changes (2 files, +41/-5)

**`src/components/XTerminal.tsx`**:
1. `wasScrolledUpRef` — tracks user scroll state via `term.onScroll`, 5-line threshold (`buf.baseY - buf.viewportY > 5`) absorbs `fit.fit()` jitter
2. `writeWithStickyBottom(data)` — captures `preBaseY`, calls `term.write(data, callback)`, measures delta post-parse, calls `term.scrollLines(-delta)` to counter-scroll
3. All 3 `term.write` call sites replaced (PTY binary, detached msg, closed msg)
4. `scrollback: 10000` (was default 1000)

**`src/components/TerminalModal.tsx:82`**:
5. Added `touchAction: 'pan-y'` + `overscrollBehavior: 'contain'` inline style — lets iOS forward vertical gestures to xterm viewport, blocks pull-to-refresh

## Build verification

`bun install && bun run build` succeeds on `bf0236d` (✓ vite build ran).

**Bundle**: `dist/assets/XTerminal-4Kk71gr-.js` (hash verified ✓ vite build ran)

**Fingerprint** (Rule v1.1): `wasScrolledUpRef` · `scrollback:1e4` · `writeWithStickyBottom` · `baseY-*.viewportY>5` · `scrollLines(-*)` — all verified present in minified bundle via grep.

## Rebase note

Branch rebased onto `af0ea56` (pre-workflow-scope barrier, same as PR#28). No workflow file diff. CI `build (node 20)` will fail on merge — pre-existing upstream `DashboardPro.tsx:200` syntax error (`1f1b155`), out of scope.

## Acceptance

- [x] `writeWithStickyBottom` wraps all `term.write` calls
- [x] `scrollback: 10000` for deeper history
- [x] `touchAction: pan-y` + `overscrollBehavior: contain` on wrapper
- [x] Build passes, bundle fingerprint verified
- [ ] Real iPhone @ office.vuttipipat.com → tap agent → terminal opens
- [ ] Scroll up 5+ lines, wait 3-5s → stays at user scroll (no snap-back on thinking dots)
- [ ] Scroll back to bottom → auto-scroll resumes on new output
- [ ] Desktop not regressed — terminal still auto-scrolls at bottom

Sibling fix: PR#28 (HoverPreviewCard desktop path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)