### PR TITLE
fix(DashboardPro): JSX syntax + plugins response shape

### DIFF
--- a/src/components/DashboardPro.tsx
+++ b/src/components/DashboardPro.tsx
@@ -196,8 +196,8 @@ function AgentGridPanel({ sessions, onRefresh }: { sessions: Session[]; onRefres
     <PanelShell title="Agents" subtitle={`${total} across ${sessions.length} sessions`}>
       <div className="flex flex-wrap gap-1">
         {sessions.flatMap((s) =>
-          s.windows.map((w) => (
-            {READONLY ? (
+          s.windows.map((w) =>
+            READONLY ? (
               <span
                 key={`${s.name}-${w.name}`}
                 className="px-1.5 py-0.5 rounded text-[10px] font-mono"
@@ -222,8 +222,8 @@ function AgentGridPanel({ sessions, onRefresh }: { sessions: Session[]; onRefres
               >
                 {acting === w.name ? "..." : w.name.replace(/-oracle$/, "")}
               </button>
-            )}
-          )),
+            ),
+          ),
         )}
       </div>
     </PanelShell>
@@ -232,15 +232,16 @@ function AgentGridPanel({ sessions, onRefresh }: { sessions: Session[]; onRefres
 
 function PluginPanel({ plugins }: { plugins: PluginStatus | null }) {
   if (!plugins) return <PanelShell title="Plugins" subtitle="loading..." />;
-  const totalEvents = plugins.plugins.reduce((n, p) => n + p.events, 0);
-  const totalErrors = plugins.plugins.reduce((n, p) => n + p.errors, 0);
+  const list: Plugin[] = Array.isArray(plugins) ? plugins : (plugins.plugins ?? []);
+  const totalEvents = list.reduce((n, p) => n + (p.events ?? 0), 0);
+  const totalErrors = list.reduce((n, p) => n + (p.errors ?? 0), 0);
   return (
     <PanelShell
       title="Plugins"
-      subtitle={`${plugins.plugins.length} loaded · ${totalEvents} events${totalErrors > 0 ? ` · ${totalErrors} errors` : ""}`}
+      subtitle={`${list.length} loaded · ${totalEvents} events${totalErrors > 0 ? ` · ${totalErrors} errors` : ""}`}
     >
       <div className="space-y-1">
-        {plugins.plugins.map((p) => (
+        {list.map((p) => (
           <div key={p.name} className="flex items-center justify-between text-xs">
             <div className="flex items-center gap-2">
               <span


### PR DESCRIPTION
## Summary

Two separate bugs in `src/components/DashboardPro.tsx` — dashboard page currently crashes on load against a live maw-js backend.

## Bug 1 — JSX parse error at `AgentGridPanel:200`

The arrow function wrote `map((w) => ({ READONLY ? ... }))`, which babel's TypeScript parser interprets as an object literal (not a JSX expression block). Result: vite dev server throws `Unexpected token, expected ','` and the page never compiles.

Fix: drop the wrapping parens so the arrow function returns the bare ternary.

## Bug 2 — Runtime crash in `PluginPanel`

`useEffect` fetches `/api/plugins`, which maw-js returns as a bare `Plugin[]` array. The component typed the prop as `PluginStatus | null` (`{ startedAt, plugins: Plugin[] }`) and called `plugins.plugins.reduce(...)`. Since `plugins.plugins` is `undefined` for the array shape, `.reduce` throws `Cannot read properties of undefined (reading 'reduce')`.

Fix: normalize with `Array.isArray(plugins) ? plugins : (plugins.plugins ?? [])` so both shapes render. Also add `?? 0` on `p.events` / `p.errors` to harden against rows that haven't recorded events yet.

## Test plan

- [x] Vite dev server compiles cleanly (`bun run dev`)
- [x] `http://localhost:5173/dashboard.html` loads without runtime error
- [x] Plugin panel renders the count returned by `/api/plugins` (20 plugins against local `maw serve`)
- [x] Agent grid renders all windows across sessions

Verified against `maw@v2.0.0-alpha.79`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)