### PR TITLE
fix(StatusBar): rewire Token panel /api/tokens/rate → /api/costs

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -93,23 +93,29 @@ function formatTokens(n: number): string {
   return `${n}`;
 }
 
-interface RateData { inputTokens: number; outputTokens: number; totalTokens: number; totalPerMin: number; inputPerMin: number; outputPerMin: number; turns: number }
+// /api/tokens/rate was deprecated (returns zeroed stub in src/api/deprecated.ts) — rewire to /api/costs.
+// /api/costs is cumulative (scans ~/.claude/projects/**/*.jsonl), not a windowed rate, so the UI
+// now answers a different question: "fleet total tokens + estimated cost" instead of "last-hour burn rate".
+interface FleetTotal { tokens: number; cost: number; sessions: number; agents: number }
 
-function useTokenRate() {
-  const [lastHourRate, setLastHourRate] = useState<RateData | null>(null);
+function useFleetTotal() {
+  const [total, setTotal] = useState<FleetTotal | null>(null);
   useEffect(() => {
     const fetch_ = () => {
-      fetch(apiUrl("/api/tokens/rate?mode=window&window=3600")).then(r => r.json()).then(d => setLastHourRate(d)).catch(() => {});
+      fetch(apiUrl("/api/costs"))
+        .then(r => r.ok ? r.json() : null)
+        .then(d => { if (d?.total) setTotal(d.total); })
+        .catch(() => {});
     };
     fetch_();
     const iv = setInterval(fetch_, 30000);
     return () => clearInterval(iv);
   }, []);
-  return { lastHourRate };
+  return { total };
 }
 
 export const StatusBar = memo(function StatusBar({ connected, agentCount, sessionCount, tabCount = 0, activeView = "office", askCount = 0, onInbox, onJump, muted, onToggleMute, children }: StatusBarProps) {
-  const { lastHourRate } = useTokenRate();
+  const { total } = useFleetTotal();
   return (
     <header className="sticky top-0 z-20 flex flex-wrap items-center gap-x-3 gap-y-2 mx-4 sm:mx-6 mt-3 px-4 sm:px-6 py-2.5 rounded-2xl bg-black/50 backdrop-blur-xl border border-white/[0.06] shadow-[0_4px_30px_rgba(0,0,0,0.4)]">
       <a href="#office" className="text-base sm:text-lg font-bold tracking-[4px] sm:tracking-[6px] text-cyan-400 uppercase whitespace-nowrap hover:text-cyan-300 transition-colors">
@@ -142,10 +148,15 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
         v{__MAW_VERSION__} · {__MAW_BUILD__}
       </span>
 
-      {lastHourRate && lastHourRate.totalTokens > 0 && (
-        <span className="text-[10px] font-mono whitespace-nowrap flex items-center gap-1" title={`Last 60min — ${formatTokens(lastHourRate.inputTokens)} in · ${formatTokens(lastHourRate.outputTokens)} out · ${lastHourRate.turns} turns`}>
-          <span className="text-amber-400/70">{formatTokens(lastHourRate.totalPerMin)}</span>
-          <span className="text-white/15">tok/min</span>
+      {total && total.tokens > 0 && (
+        <span
+          className="text-[10px] font-mono whitespace-nowrap flex items-center gap-1"
+          title={`Fleet total — ${formatTokens(total.tokens)} tokens · $${total.cost.toFixed(2)} est · ${total.sessions} sessions · ${total.agents} agents (source: /api/costs)`}
+          aria-label={`Fleet total ${formatTokens(total.tokens)} tokens, estimated cost ${total.cost.toFixed(2)} dollars`}
+        >
+          <span className="text-amber-400/70">{formatTokens(total.tokens)}</span>
+          <span className="text-white/15">tok</span>
+          {total.cost > 0 && <span className="text-emerald-400/70">· ${total.cost.toFixed(0)}</span>}
         </span>
       )}
 


### PR DESCRIPTION
## Summary

The StatusBar's fleet-tokens pill was silently dead: `/api/tokens/rate` returns a zeroed stub in `src/api/deprecated.ts` of `maw-js`, so the display was gated off by `lastHourRate.totalTokens > 0` and never rendered. This PR rewires it to `/api/costs` — same pattern already applied to `DashboardView.tsx` in b80b671 ("fix: hash routing, mission cards, live terminal flicker, token costs").

## User need (Rule #1 — every pixel serves a user need)

Leo + the fleet operator want a glanceable answer to **"how much has the fleet consumed?"** in the status bar without opening a panel. The current pill answers nothing because data is zero. After this PR, it answers: **fleet total tokens + estimated cost**, updating every 30s.

## What changed

- `useTokenRate()` → `useFleetTotal()` — fetches `/api/costs` instead of `/api/tokens/rate`.
- `RateData` interface → `FleetTotal` interface matching `/api/costs` `total` shape: `{ tokens, cost, sessions, agents }`.
- Display copy: `{X} tok/min` → `{X} tok · ${Y}` (cost only if > 0). Tooltip copy describes the honest new semantics, including data source `/api/costs` for debuggability.

**Semantic shift (intentional + honest):** `/api/costs` is cumulative (scans `~/.claude/projects/**/*.jsonl`), not a windowed rate. The pill now answers a different question than before — "fleet total" instead of "last-hour burn rate". No silent relabel; tooltip + aria-label name the new meaning explicitly.

## Accessibility checklist (Rule #2 — a11y by default)

- [x] `aria-label` added — screen readers hear full semantics, not just \"1.6B tok\".
- [x] Tooltip (`title`) names the data source so a future engineer can trace the number.
- [x] Contrast preserved (amber-400/70 on black/50 passes WCAG AA).
- [x] No new interactive elements; keyboard nav unchanged.
- [x] Focus states unchanged (pill is a passive `<span>`).
- [x] No form fields added.

## State checklist (Rule #3 — state is data + derivation)

- [x] No new component-internal state beyond the existing `useState`/`useEffect` pattern used by the old hook.
- [x] Inspectable: Network tab shows `/api/costs`, React DevTools shows `FleetTotal`.
- [x] Re-fetch interval (30s) unchanged from prior behavior.

## Verification

- `bunx tsc --noEmit` — zero errors from `StatusBar.tsx`.
- `/api/costs` shape confirmed against a running `maw-js` server: returns `{ agents: [...], total: { tokens, cost, sessions, agents } }` — matches `FleetTotal` exactly.
- **Blocker for full in-browser verification:** pre-existing build error in `src/components/DashboardPro.tsx:200` from PR #26 (`READONLY ? (...) : (...)` inside a `.map(w => (...))` without a fragment wrapper). Unrelated to this PR; I'll file a separate issue.

## Test plan

- [ ] Pull locally, run `bun run dev` (after unblocking the DashboardPro.tsx build error).
- [ ] Open the dashboard with `maw-js` serving `/api/costs` — confirm pill renders `{tokens} tok · ${cost}` in the status bar.
- [ ] Hover the pill — tooltip shows full fleet breakdown.
- [ ] Use a screen reader (VoiceOver / NVDA) — confirm aria-label reads the full sentence.
- [ ] Stop `maw-js` — confirm pill disappears (gated by `total.tokens > 0`), doesn't error.

---

🌬️ VELA Oracle (AI — per Oracle family Rule 6 transparency)
UX / Frontend Engineer of Kaiju Software Dev Team