### PR TITLE
fix(chat): rewire useChatLog /api/maw-log → /api/feed + 410 discriminate

### DIFF
--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -13,7 +13,7 @@ export const ChatView = memo(function ChatView() {
   const [mode, setMode] = useState<Mode>("timeline");
   const [highlighted, setHighlighted] = useState<string | null>(null);
 
-  const { entries, total, loading, scrollRef } = useChatLog(mode);
+  const { entries, total, loading, sourceError, scrollRef } = useChatLog(mode);
   const oracleNames = useOracleNames(entries);
   const filtered = useFilteredEntries(entries, filter);
   const grouped = useTimelineGroups(filtered);
@@ -84,7 +84,17 @@ export const ChatView = memo(function ChatView() {
 
       {/* Chat area */}
       <div ref={scrollRef} className="flex-1 overflow-y-auto px-4 py-4">
-        {loading ? (
+        {sourceError ? (
+          <div
+            role="alert"
+            aria-live="polite"
+            className="flex flex-col items-center justify-center h-full gap-2 px-4"
+          >
+            <p className="text-red-400/80 text-sm font-mono">chat source unavailable</p>
+            <p className="text-white/40 text-xs font-mono max-w-md text-center">{sourceError}</p>
+            <p className="text-white/25 text-[10px] font-mono">source: <code className="text-white/40">/api/feed</code> — see server logs or retry</p>
+          </div>
+        ) : loading ? (
           <div className="flex items-center justify-center h-full">
             <span className="text-white/20 text-sm font-mono">Loading...</span>
           </div>

--- a/src/components/chat/useChatLog.ts
+++ b/src/components/chat/useChatLog.ts
@@ -2,26 +2,86 @@ import { useState, useEffect, useMemo, useRef } from "react";
 import { type MawLogEntry, formatDate, pairKey } from "./types";
 import { apiUrl, wsUrl } from "../../lib/api";
 
+// /api/feed event shape — public federation API v1 (maw-js src/api/feed.ts).
+// Chat view consumes this since /api/maw-log was rotated to 410 Gone
+// (FORGE maw-js fb9f599, 2026-04-18) with successor /api/feed.
+interface FeedEvent {
+  timestamp: string;
+  oracle: string;
+  host: string;
+  event: string;
+  project: string;
+  sessionId: string;
+  message: string;
+  ts: number;
+}
+
+// Parse "recipient: body" prefix from feed message text.
+// Returns [to, msg] on match, or [null, original] when no prefix.
+// Heuristic: take first colon if followed by space, recipient ≤ 40 chars,
+// no whitespace in recipient. Tolerant — failed parses drop the event
+// (same filter the old /api/maw-log consumer applied: require from && to).
+function parseRecipient(message: string): [string | null, string] {
+  const m = message.match(/^([a-z0-9_-]{1,40}):\s+(.+)$/is);
+  if (!m) return [null, message];
+  return [m[1].toLowerCase(), m[2]];
+}
+
+function feedEventToLogEntry(e: FeedEvent): MawLogEntry | null {
+  if (e.event !== "MessageSend") return null;
+  const [to, msg] = parseRecipient(e.message);
+  if (!to) return null;
+  return { ts: e.timestamp, from: e.oracle, to, msg };
+}
+
 export function useChatLog(mode: string) {
   const [entries, setEntries] = useState<MawLogEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
+  const [sourceError, setSourceError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  // Initial fetch
+  // Initial fetch — /api/feed?limit=200 (server caps at 200 per feed.ts:21).
+  // Lens-2 discrimination: 410 Gone from a deprecated-route caller surfaces
+  // visibly via sourceError, not as silent empty entries. See
+  // ~/david-oracle/ψ/memory/vela/patterns/2026-04-18_silent-errors-deprecated-endpoints.md
   useEffect(() => {
     setLoading(true);
-    fetch(apiUrl("/api/maw-log?limit=500"))
-      .then((r) => r.json())
+    setSourceError(null);
+    fetch(apiUrl("/api/feed?limit=200"))
+      .then(async (r) => {
+        if (r.status === 410) {
+          const body = await r.json().catch(() => ({}));
+          setSourceError(`chat source deprecated (410 Gone). replacement: ${body?.replacement ?? "unknown"}`);
+          setLoading(false);
+          return null;
+        }
+        if (!r.ok) {
+          setSourceError(`chat source unreachable (HTTP ${r.status})`);
+          setLoading(false);
+          return null;
+        }
+        return r.json();
+      })
       .then((data) => {
-        setEntries((data.entries || []).filter((e: MawLogEntry) => e.from && e.to));
-        setTotal(data.total || 0);
+        if (!data) return;
+        const mapped: MawLogEntry[] = (data.events ?? [])
+          .map(feedEventToLogEntry)
+          .filter((e: MawLogEntry | null): e is MawLogEntry => e !== null);
+        setEntries(mapped);
+        setTotal(mapped.length);
         setLoading(false);
       })
-      .catch(() => setLoading(false));
+      .catch((err) => {
+        setSourceError(`chat source fetch failed: ${err?.message ?? "network error"}`);
+        setLoading(false);
+      });
   }, []);
 
-  // Real-time: listen for WebSocket push of new maw-log entries
+  // Real-time: listen for WebSocket push. Handles both "maw-log" (legacy payload
+  // type, retained for back-compat — no matches in current maw-js src but cheap
+  // to keep per Principle 1 "Nothing is Deleted") and "feed" (the new type
+  // emitted alongside FORGE's 410 rotation, if/when server pushes per-event).
   useEffect(() => {
     const url = wsUrl("/ws");
     let ws: WebSocket | null = null;
@@ -30,9 +90,17 @@ export function useChatLog(mode: string) {
       ws.onmessage = (ev) => {
         try {
           const msg = JSON.parse(ev.data);
+          let incoming: MawLogEntry[] = [];
           if (msg.type === "maw-log" && msg.entries) {
-            setEntries(prev => [...prev, ...msg.entries]);
-            setTotal(prev => prev + msg.entries.length);
+            incoming = msg.entries;
+          } else if (msg.type === "feed" && Array.isArray(msg.events)) {
+            incoming = msg.events
+              .map(feedEventToLogEntry)
+              .filter((e: MawLogEntry | null): e is MawLogEntry => e !== null);
+          }
+          if (incoming.length > 0) {
+            setEntries(prev => [...prev, ...incoming]);
+            setTotal(prev => prev + incoming.length);
             if (mode === "live") {
               requestAnimationFrame(() => {
                 scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
@@ -45,7 +113,7 @@ export function useChatLog(mode: string) {
     return () => { ws?.close(); };
   }, [mode]);
 
-  return { entries, total, loading, scrollRef };
+  return { entries, total, loading, sourceError, scrollRef };
 }
 
 export function useOracleNames(entries: MawLogEntry[]) {


### PR DESCRIPTION
## Summary

Ship-alongside Lens-2 companion to FORGE's [maw-js#504](https://github.com/Soul-Brews-Studio/maw-js) (`fb9f599` — 410 Gone rotation of deprecated endpoints). Without this rewire, once FORGE's rotation merges the chat log (`#chat`) goes silently empty — exact failure mode the [silent-errors-deprecated-endpoints pattern](https://github.com/Soul-Brews-Studio/maw-ui/blob/main/../../david-oracle/ψ/memory/vela/patterns/2026-04-18_silent-errors-deprecated-endpoints.md) predicts.

**Paired-Oracle Lens-1 (FORGE server 410) + Lens-2 (VELA client discrimination)** as a live demonstration of the pattern's thesis. FORGE agreed to hold maw-js#504 merge until this lands (2026-04-18 Option B).

## User need (Rule #1)

Leo opens `#chat`, expects the last 200 inter-Oracle messages. Post-FORGE-rotation without this PR: empty page with "No messages yet" (lies — messages exist, source is dead). With this PR: either the real chat, or a visible "chat source unavailable (410 Gone)" banner pointing at `/api/feed`. No silent-empty failure mode.

## What changed

**`src/components/chat/useChatLog.ts`**:
- Fetch shifted: `/api/maw-log?limit=500` → `/api/feed?limit=200` (server caps at 200 in `feed.ts:21`; old 500 was maw-log-specific)
- New `feedEventToLogEntry()` adapter parses `"recipient: body"` prefix from `MessageSend` events, filters `SessionEnd` and un-prefixed messages — preserves the old hook's `e.from && e.to` guarantee
- **Lens-2 discrimination**: 410 → `sourceError` with replacement URL from body; non-OK HTTP → "unreachable HTTP N"; fetch fail → "fetch failed: <message>". No more silent empty on dead endpoint.
- WebSocket handler accepts both `"maw-log"` (legacy, kept per Principle 1) and `"feed"` message types; `"feed"` applies the same adapter. Cheap back-compat.

**`src/components/ChatView.tsx`**:
- Renders `sourceError` visibly with `role="alert"` + `aria-live="polite"` — screen readers hear the error, not an empty "No messages yet"
- Source named explicitly (`/api/feed`) in the error body for debuggability

## Rule checklist

- [x] **Rule #1** — banner answers concrete user question ("why is chat empty?"); adapter drops only unprocessable events (same contract as before)
- [x] **Rule #2** — `role="alert"` + `aria-live="polite"` on error banner; error copy names data source; contrast preserved (red-400/80 + white/40 on #0a0a0f)
- [x] **Rule #3** — `sourceError` in hook-level state (inspectable via React DevTools), fetch visible in Network tab, no hidden component state

## Verification

- `bunx tsc --noEmit` clean on touched files. (`DashboardPro.tsx` pre-existing bug #32 unrelated)
- **Adapter smoke against live `/api/feed`**: 48/50 events mapped cleanly; 2 `SessionEnd` events correctly dropped; recipients resolve including numeric-prefix names (`14-watchdog`, `10-helm`) preserved from legacy shape
- Browser dev verification blocked by pre-existing `DashboardPro.tsx` build error (issue #32) — same blocker flagged on PR1 (#31)

## Sequencing

**Merge this PR first. Then FORGE merges [maw-js#504](https://github.com/Soul-Brews-Studio/maw-js).** Zero-window on silent-empty chat. Paired-Oracle review loop visible in the wild.

FORGE has committed to hold their merge until this lands (2026-04-18 ack). NEXUS is looped in for synchronized deploy.

## Test plan

- [ ] Pull locally, point at a maw-js running `fb9f599` (or any server with `/api/feed`), `bun run dev`, open `#chat` — verify messages render as before
- [ ] Flip maw-js to a build that 410s `/api/maw-log` only (pre-rotation state) — verify the fetch of `/api/feed` still works (no regression)
- [ ] Point at a maw-js with `/api/feed` intentionally broken (e.g., 500) — verify `chat source unavailable` banner renders with correct source name + `aria-live` announcement
- [ ] Screen reader sweep (VoiceOver / NVDA) on the error banner — confirm `role="alert"` fires on first render
- [ ] WebSocket: confirm both `"maw-log"` (legacy) and `"feed"` incoming types append to entries

## Related

- **Pattern**: `~/david-oracle/ψ/memory/vela/patterns/2026-04-18_silent-errors-deprecated-endpoints.md` — this PR is its first worked instance catching a hazard before rotation merged (catch ratio 1/1)
- **Peer**: `~/david-oracle/ψ/memory/forge/patterns/2026-04-18_adversarial-test-design.md` — same two-lens class, different domain
- **Predecessor**: [#31](https://github.com/Soul-Brews-Studio/maw-ui/pull/31) — StatusBar rewire was the Lens-2 exemplar that taught this pattern
- **Blocker**: [#32](https://github.com/Soul-Brews-Studio/maw-ui/issues/32) — pre-existing `DashboardPro.tsx` build error blocks full in-browser verification

---

🌬️ VELA Oracle (AI — per Oracle family Rule 6 transparency)
UX / Frontend Engineer of Kaiju Software Dev Team