### PR TITLE
fix(xterm): auto-copy drag selection to browser clipboard

### DIFF
--- a/src/components/XTerminal.tsx
+++ b/src/components/XTerminal.tsx
@@ -72,6 +72,7 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
     let ws: WebSocket | null = null;
     let dataSub: { dispose: () => void } | null = null;
     let binSub: { dispose: () => void } | null = null;
+    let selectionSub: { dispose: () => void } | null = null;
     let resizeTimer: ReturnType<typeof setTimeout>;
     let resizeObserver: ResizeObserver | null = null;
 
@@ -82,6 +83,15 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
         fit.fit();
         term.focus();
       } catch { return; }
+
+      // Drag-select → browser clipboard. Last selection wins; clipboard API
+      // may reject in insecure contexts — silently ignore.
+      selectionSub = term.onSelectionChange(() => {
+        const sel = term.getSelection();
+        if (sel && sel.length > 0) {
+          navigator.clipboard.writeText(sel).catch(() => {});
+        }
+      });
 
       // Connect to PTY WebSocket
       ws = new WebSocket(wsUrl("/ws/pty"));
@@ -171,6 +181,7 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
       resizeObserver?.disconnect();
       dataSub?.dispose();
       binSub?.dispose();
+      selectionSub?.dispose();
       ws?.close();
       term.dispose();
     };


### PR DESCRIPTION
## Problem

tmux running inside xterm.js consumed mouse drag selection into its own buffer, so browser-level Cmd+C after drag produced nothing in the clipboard. Users watching PaoPao/Oracle panes couldn't copy URLs or commands by drag-selecting.

## Fix

Wire `term.onSelectionChange` → `navigator.clipboard.writeText(selection)`:

- Drag releases → selection settles → last selection lands in OS clipboard
- Silent catch on rejection (clipboard API fails in insecure http:// contexts; don't surface to users)
- Subscription disposed alongside `dataSub`/`binSub` on unmount

3 additions in `src/components/XTerminal.tsx` (+11 lines net).

## Test plan

- [ ] Drag-select text in any terminal pane → Cmd+V in another app → pasted
- [ ] Verify selection clears don't trigger empty clipboard writes
- [ ] Verify no regression on keyboard entry / tmux mouse mode
- [ ] Verify subscription cleanup on pane close (no memory leak)

🤖 Generated with [Claude Code](https://claude.com/claude-code)