### PR TITLE
fix(#27): preserve scroll position in hover/preview card

### DIFF
--- a/src/components/HoverPreviewCard.tsx
+++ b/src/components/HoverPreviewCard.tsx
@@ -165,31 +165,26 @@ export const HoverPreviewCard = memo(function HoverPreviewCard({
     return () => { active = false; };
   }, [agent.target]);
 
-  // Auto-scroll to bottom — smooth when pinned, instant on hover
-  const userScrolledRef = useRef(false);
+  // Track near-bottom in BOTH pinned and hover modes — previously the scroll
+  // listener was gated on `pinned`, so hover mode had no user-intent signal
+  // and every content poll yanked back to bottom mid-read.
+  const wasAtBottomRef = useRef(true);
   useEffect(() => {
     const el = termRef.current;
     if (!el) return;
-    // If user scrolled up in pinned mode, don't force scroll
-    if (pinned && userScrolledRef.current) return;
-    if (pinned) {
-      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
-    } else {
-      el.scrollTop = el.scrollHeight;
-    }
-  }, [content, pinned]);
+    const onScroll = () => {
+      wasAtBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, []);
 
-  // Detect user scroll-up to pause auto-scroll (re-enable when near bottom)
   useEffect(() => {
     const el = termRef.current;
-    if (!el || !pinned) return;
-    const onScroll = () => {
-      const nearBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
-      userScrolledRef.current = !nearBottom;
-    };
-    el.addEventListener("scroll", onScroll);
-    return () => el.removeEventListener("scroll", onScroll);
-  }, [pinned]);
+    if (!el || !wasAtBottomRef.current) return;
+    if (pinned) el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    else el.scrollTop = el.scrollHeight;
+  }, [content, pinned]);
 
   // Deterministic chibi features (same logic as AgentAvatar)
   let h = 0;


### PR DESCRIPTION
## Summary

Auto-scroll yanked back to bottom on every 500ms content poll, even after user scrolled up to read. Two bugs in `HoverPreviewCard.tsx:168-192`:

1. **Hover mode** unconditional `el.scrollTop = el.scrollHeight` on `content` change — no user-intent check.
2. **Scroll listener gated on `pinned`** → `userScrolledRef` never updated in hover mode → pinned-mode guard could never protect hover mode either.

## Fix

Single scroll listener runs in both modes, updates `wasAtBottomRef`. Auto-scroll skips when user is not near bottom; re-engages once they scroll back down.

Same pattern as `BankCurfew/oracle-dashboard#13`.

## Test plan

- [ ] Open `god.buildwithoracle.com`, tap oracle avatar → hover card opens
- [ ] Scroll up 40+ px, wait 5s (several poll ticks) — stays put
- [ ] Scroll back to bottom — auto-scroll resumes on next update
- [ ] Pin card, repeat — smooth scroll behavior unchanged

Closes #27