### PR TITLE
fix(types): PaneStatus 'crashed' branch + PanelShell optional children

### DIFF
--- a/src/components/AgentAvatar.tsx
+++ b/src/components/AgentAvatar.tsx
@@ -4,9 +4,10 @@ import { useAgentPreview } from "../lib/previewStore";
 import type { PaneStatus } from "../lib/types";
 
 const STATUS_FX: Record<PaneStatus, { color: string; aura: number; sparkle: boolean; typing: boolean }> = {
-  ready: { color: "#4caf50", aura: 1, sparkle: false, typing: false },
-  busy:  { color: "#fdd835", aura: 2, sparkle: true, typing: true },
-  idle:  { color: "#666",    aura: 0, sparkle: false, typing: false },
+  ready:   { color: "#4caf50", aura: 1, sparkle: false, typing: false },
+  busy:    { color: "#fdd835", aura: 2, sparkle: true,  typing: true  },
+  idle:    { color: "#666",    aura: 0, sparkle: false, typing: false },
+  crashed: { color: "#ef4444", aura: 0, sparkle: false, typing: false },
 };
 
 interface AgentAvatarProps {

--- a/src/components/BoardView.tsx
+++ b/src/components/BoardView.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect, useCallback, useMemo } from "react";
 import { useFleetStore } from "../lib/store";
-import type { BoardItem, BoardField, ScanResult, ScanMineResult, TimelineItem, AgentState, PulseBoard } from "../lib/types";
+import type { BoardItem, BoardField, ScanResult, ScanMineResult, TimelineItem, AgentState, PulseBoard, PaneStatus } from "../lib/types";
 import { TaskDetailOverlay } from "./TaskDetailOverlay";
 import { ProjectBoardView } from "./ProjectBoardView";
 
@@ -11,9 +11,9 @@ interface BoardViewProps {
 }
 
 /** Map oracle field value → live agent status */
-function useOracleStatusMap(agents: AgentState[]): Map<string, "busy" | "ready" | "idle"> {
+function useOracleStatusMap(agents: AgentState[]): Map<string, PaneStatus> {
   return useMemo(() => {
-    const m = new Map<string, "busy" | "ready" | "idle">();
+    const m = new Map<string, PaneStatus>();
     for (const a of agents) {
       // oracle names in board: "dev", "qa", "researcher", etc.
       // agent names in tmux: "dev-oracle", "researcher-oracle", or "dev-projectname"
@@ -244,8 +244,11 @@ function EditableCell({
 
 // --- Live oracle status indicator ---
 
-function OracleActivity({ status }: { status?: "busy" | "ready" | "idle" }) {
+function OracleActivity({ status }: { status?: PaneStatus }) {
   if (!status || status === "idle") return null;
+  if (status === "crashed") {
+    return <span className="inline-flex ml-1 w-2 h-2 rounded-full bg-red-500 animate-pulse" />;
+  }
   if (status === "busy") {
     return (
       <span className="relative inline-flex ml-1">

--- a/src/components/DashboardPro.tsx
+++ b/src/components/DashboardPro.tsx
@@ -302,7 +302,7 @@ function PanelShell({
 }: {
   title: string;
   subtitle?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 }) {
   return (
     <div className="rounded-lg border border-white/[0.08] bg-white/[0.03] p-3">

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -6,7 +6,7 @@ import { describeActivity, type FeedEvent } from "../lib/feed";
 import { useFleetStore } from "../lib/store";
 import { useAgentPreview } from "../lib/previewStore";
 import { useFeedStatusStore, useLiveStatus, useAllStatuses } from "../lib/feedStatusStore";
-import type { AgentState, Session, AgentEvent } from "../lib/types";
+import type { AgentState, Session, AgentEvent, PaneStatus } from "../lib/types";
 
 // ─── Token types ────────────────────────────────────────────────────
 interface TokenSession {
@@ -55,10 +55,11 @@ function timeAgo(ts: number): string {
   return `${Math.floor(diff / 86400_000)}d ago`;
 }
 
-const STATUS_CONFIG = {
-  busy: { color: "#fbbf24", bg: "rgba(251,191,36,0.12)", glow: "0 0 8px rgba(251,191,36,0.4)", label: "BUSY", dot: "bg-amber-400 animate-pulse shadow-[0_0_6px_#ffa726]" },
-  ready: { color: "#22c55e", bg: "rgba(34,197,94,0.10)", glow: "0 0 6px rgba(34,197,94,0.3)", label: "READY", dot: "bg-emerald-400 shadow-[0_0_4px_#4caf50]" },
-  idle: { color: "#64748b", bg: "rgba(100,116,139,0.06)", glow: "none", label: "IDLE", dot: "bg-white/20" },
+const STATUS_CONFIG: Record<PaneStatus, { color: string; bg: string; glow: string; label: string; dot: string }> = {
+  busy:    { color: "#fbbf24", bg: "rgba(251,191,36,0.12)", glow: "0 0 8px rgba(251,191,36,0.4)", label: "BUSY",    dot: "bg-amber-400 animate-pulse shadow-[0_0_6px_#ffa726]" },
+  ready:   { color: "#22c55e", bg: "rgba(34,197,94,0.10)",  glow: "0 0 6px rgba(34,197,94,0.3)",  label: "READY",   dot: "bg-emerald-400 shadow-[0_0_4px_#4caf50]" },
+  idle:    { color: "#64748b", bg: "rgba(100,116,139,0.06)", glow: "none",                         label: "IDLE",    dot: "bg-white/20" },
+  crashed: { color: "#ef4444", bg: "rgba(239,68,68,0.14)",  glow: "0 0 8px rgba(239,68,68,0.4)",  label: "CRASHED", dot: "bg-red-500 animate-pulse shadow-[0_0_6px_#ef4444]" },
 };
 
 // ─── Status Overview Panel ──────────────────────────────────────────

--- a/src/components/iPadDashboard.tsx
+++ b/src/components/iPadDashboard.tsx
@@ -7,13 +7,14 @@ import { ChibiPortrait } from "./ChibiPortrait";
 import { useFileAttach, FileInput, AttachmentChips } from "../hooks/useFileAttach";
 import { useDevice } from "../hooks/useDevice";
 import { FULL_COMMANDS } from "../quickCommands";
-import type { AgentState } from "../lib/types";
+import type { AgentState, PaneStatus } from "../lib/types";
 
 // --- Status colors ---
-const STATUS = {
-  busy: { color: "#fdd835", bg: "rgba(253,216,53,0.12)", label: "BUSY" },
-  ready: { color: "#4caf50", bg: "rgba(76,175,80,0.12)", label: "READY" },
-  idle: { color: "#666", bg: "rgba(102,102,102,0.08)", label: "IDLE" },
+const STATUS: Record<PaneStatus, { color: string; bg: string; label: string }> = {
+  busy:    { color: "#fdd835", bg: "rgba(253,216,53,0.12)", label: "BUSY" },
+  ready:   { color: "#4caf50", bg: "rgba(76,175,80,0.12)", label: "READY" },
+  idle:    { color: "#666",    bg: "rgba(102,102,102,0.08)", label: "IDLE" },
+  crashed: { color: "#ef4444", bg: "rgba(239,68,68,0.14)",   label: "CRASHED" },
 };
 
 // --- Agent Mini Card (touch-friendly 44px+ targets) ---


### PR DESCRIPTION
## Summary

Type-error batch from repo audit — 37 → 25 `tsc --noEmit` errors, no runtime behavior change (build was already passing because Vite/esbuild transpiles, not typechecks).

## What changed

- **STATUS_FX / STATUS_CONFIG / STATUS** lookup tables in \`AgentAvatar\`, \`DashboardView\`, \`iPadDashboard\` missing \`crashed\` key — added red pulse styling + explicit \`Record<PaneStatus, …>\` typing so any future \`PaneStatus\` additions surface at compile time instead of silently falling through to \`|| STATUS.idle\`.
- **BoardView.useOracleStatusMap** was typed \`Map<string, 'busy'|'ready'|'idle'>\` but \`a.status\` is \`PaneStatus\` — broadened Map type + \`OracleActivity\` prop to \`PaneStatus\`, added red-pulse dot for crashed oracles.
- **DashboardPro.PanelShell** required \`children\`, but \`PeerHealthPanel\` / \`ClockDriftPanel\` / \`PluginPanel\` emit \`<PanelShell title=… subtitle=\"loading...\" />\` during the loading state. Made \`children\` optional.

## Remaining TS errors (25, deferred to separate PR)

- \`src/lib/peer*.test.ts\` — \`Cannot find module 'bun:test'\` (needs \`"types": ["bun-types"]\` in tsconfig)
- \`FleetGrid.tsx\` — 3 function-arity mismatches
- \`ConfigView.tsx:405\` — Array.map callback arity
- \`MissionControl.tsx\` — ClusterItem shape / null deref
- \`OracleSearch.tsx:70\` — SearchResponse missing \`.error\`

## Test plan

- [x] \`bun run build\` succeeds
- [x] \`bun tsc --noEmit\` errors drop from 37 → 25
- [ ] No visual regression on god.buildwithoracle.com (crashed oracles now show red pulse; no live crashed state to verify)