### PR TITLE
fix(api): circuit breaker for stuck pollers + PNA-aware fetch wrapper

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,8 @@ import { DashboardView } from "./components/DashboardView";
 import FederationView from "./components/FederationView";
 import DashboardPro from "./components/DashboardPro";
 import { ConnectPage } from "./components/ConnectPage";
-import { isRemote, activeHost, clearStoredHost } from "./lib/api";
+import { isRemote, activeHost, clearStoredHost, resetHttpHealth } from "./lib/api";
+import { useHttpHealth } from "./hooks/useHttpHealth";
 import { JarvisView } from "./components/JarvisView";
 // BoBFaceView, BoardView, LoopsView, HallOfFameView, IPadDashboard
 // removed from nav — no upstream backends. Files kept per Nothing is Deleted.
@@ -197,18 +198,24 @@ function Layout({ activeView, connected, reconnecting, agentCount, sessionCount,
     ? "relative flex flex-col h-screen overflow-hidden"
     : "relative min-h-screen";
 
-  // Self-healing: if remote host hasn't connected after 8s, surface a banner
-  // so the user can disconnect/change host without DevTools.
-  const [stale, setStale] = useState(false);
+  // Self-healing: surface a banner when the remote host is unreachable.
+  // Two trip conditions:
+  //   (a) WS hasn't opened within 8s (host wrong / unreachable)
+  //   (b) Circuit breaker tripped (Chrome PNA blocks, 5xx storm, etc.)
+  // (b) catches the case where WS connects but HTTP polls are blocked.
+  const httpHealth = useHttpHealth();
+  const [wsLate, setWsLate] = useState(false);
   useEffect(() => {
     if (!isRemote) return;
-    if (connected) { setStale(false); return; }
-    const t = setTimeout(() => setStale(true), 8000);
+    if (connected) { setWsLate(false); return; }
+    const t = setTimeout(() => setWsLate(true), 8000);
     return () => clearTimeout(t);
   }, [connected]);
+  const stale = isRemote && (wsLate || !httpHealth.healthy);
 
   const onDisconnect = useCallback(() => {
     clearStoredHost();
+    resetHttpHealth();
     window.location.reload();
   }, []);
 
@@ -236,10 +243,14 @@ function Layout({ activeView, connected, reconnecting, agentCount, sessionCount,
             <span className="text-lg">⚠️</span>
             <div className="flex-1 min-w-0">
               <p className="font-mono text-xs" style={{ color: "#fca5a5" }}>
-                Can't reach <span className="font-bold">{activeHost}</span>
+                {!httpHealth.healthy
+                  ? <>Requests blocked — <span className="font-bold">{activeHost}</span></>
+                  : <>Can't reach <span className="font-bold">{activeHost}</span></>}
               </p>
               <p className="font-mono text-[10px]" style={{ color: "rgba(255,255,255,0.4)" }}>
-                Host unreachable from this network. Disconnect to pick another, or check the LAN.
+                {!httpHealth.healthy
+                  ? <>Circuit open after {httpHealth.consecutiveFails} failures ({httpHealth.lastError || "network"}). Chrome PNA may be blocking HTTP→LAN — try https:// or change host.</>
+                  : <>Host unreachable from this network. Disconnect to pick another, or check the LAN.</>}
               </p>
             </div>
             <button

--- a/src/components/HoverPreviewCard.tsx
+++ b/src/components/HoverPreviewCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef, useCallback, memo } from "react";
 import { ansiToHtml, processCapture } from "../lib/ansi";
 import { agentColor, PREVIEW_CARD } from "../lib/constants";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/api";
 import { useAgentPreview } from "../lib/previewStore";
 import type { AgentState, AgentEvent } from "../lib/types";
 
@@ -152,7 +152,7 @@ export const HoverPreviewCard = memo(function HoverPreviewCard({
     let active = true;
     async function poll() {
       try {
-        const res = await fetch(apiUrl(`/api/capture?target=${encodeURIComponent(agent.target)}`));
+        const res = await apiFetch(`/api/capture?target=${encodeURIComponent(agent.target)}`);
         const data = await res.json();
         if (active) setContent(prev => {
           const next = data.content || "";

--- a/src/components/MiniMonitor.tsx
+++ b/src/components/MiniMonitor.tsx
@@ -1,6 +1,6 @@
 import { memo, useState, useEffect, useRef } from "react";
 import { ansiToHtml, processCapture } from "../lib/ansi";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/api";
 
 interface MiniMonitorProps {
   target: string;
@@ -60,7 +60,7 @@ export const MiniMonitor = memo(function MiniMonitor({
     let active = true;
     async function poll() {
       try {
-        const res = await fetch(apiUrl(`/api/capture?target=${encodeURIComponent(target)}`));
+        const res = await apiFetch(`/api/capture?target=${encodeURIComponent(target)}`);
         const data = await res.json();
         const text = data.content || "";
         if (!active) return;
@@ -92,7 +92,7 @@ export const MiniMonitor = memo(function MiniMonitor({
   useEffect(() => {
     if (mountedRef.current) return;
     mountedRef.current = true;
-    fetch(apiUrl(`/api/capture?target=${encodeURIComponent(target)}`))
+    apiFetch(`/api/capture?target=${encodeURIComponent(target)}`)
       .then(r => r.json())
       .then(data => {
         const text = data.content || "";

--- a/src/components/MiniPreview.tsx
+++ b/src/components/MiniPreview.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, memo } from "react";
 import { ansiToHtml, processCapture } from "../lib/ansi";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/api";
 
 interface MiniPreviewProps {
   agent: { target: string; name: string; status: string };
@@ -23,7 +23,7 @@ export const MiniPreview = memo(function MiniPreview({ agent, accent, roomLabel 
 
   useEffect(() => {
     let active = true;
-    fetch(apiUrl(`/api/capture?target=${encodeURIComponent(agent.target)}`))
+    apiFetch(`/api/capture?target=${encodeURIComponent(agent.target)}`)
       .then(r => r.json())
       .then(d => { if (active) setContent(d.content || ""); })
       .catch(() => {});

--- a/src/components/OverviewGrid.tsx
+++ b/src/components/OverviewGrid.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useEffect, useRef, useMemo } from "react";
 import { ansiToHtml, processCapture } from "../lib/ansi";
 import { roomStyle, agentColor } from "../lib/constants";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/api";
 import { useFps } from "./FpsCounter";
 import { useFleetStore } from "../lib/store";
 import type { AgentState, Session } from "../lib/types";
@@ -62,7 +62,7 @@ const OverviewTile = memo(function OverviewTile({
     async function poll() {
       if (!activeRef.current) return;
       try {
-        const res = await fetch(apiUrl(`/api/capture?target=${encodeURIComponent(agent.target)}`));
+        const res = await apiFetch(`/api/capture?target=${encodeURIComponent(agent.target)}`);
         const data = await res.json();
         if (activeRef.current) setContent(data.content || "");
       } catch {}

--- a/src/components/PinLock.tsx
+++ b/src/components/PinLock.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useEffect, useRef } from "react";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/api";
 
 const STORAGE_KEY = "office-unlocked";
 
@@ -14,7 +14,7 @@ export function PinLock({ children }: { children: React.ReactNode }) {
   // Fetch PIN config from server
   useEffect(() => {
     if (unlocked) return;
-    fetch(apiUrl("/api/pin-info"))
+    apiFetch("/api/pin-info")
       .then(r => r.json())
       .then(data => {
         setPinLength(data.length || 4);
@@ -34,7 +34,7 @@ export function PinLock({ children }: { children: React.ReactNode }) {
       const next = [...prev, d];
       if (next.length === pinLength) {
         // Verify server-side
-        fetch(apiUrl("/api/pin-verify"), {
+        apiFetch("/api/pin-verify", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ pin: next.join("") }),

--- a/src/components/VSAgentPanel.tsx
+++ b/src/components/VSAgentPanel.tsx
@@ -2,7 +2,7 @@ import { memo, useState, useEffect, useRef, useCallback } from "react";
 import { AgentAvatar } from "./AgentAvatar";
 import { agentColor } from "../lib/constants";
 import { ansiToHtml, processCapture } from "../lib/ansi";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/api";
 import type { AgentState } from "../lib/types";
 
 interface VSAgentPanelProps {
@@ -26,7 +26,7 @@ export const VSAgentPanel = memo(function VSAgentPanel({ agent, send, onPickAgen
     send({ type: "subscribe", target: agent.target });
     const poll = setInterval(async () => {
       try {
-        const res = await fetch(apiUrl(`/api/capture?target=${encodeURIComponent(agent.target)}`));
+        const res = await apiFetch(`/api/capture?target=${encodeURIComponent(agent.target)}`);
         const data = await res.json();
         setContent(data.content || "");
       } catch {}

--- a/src/hooks/useHttpHealth.ts
+++ b/src/hooks/useHttpHealth.ts
@@ -1,0 +1,6 @@
+import { useSyncExternalStore } from "react";
+import { getHttpHealth, subscribeHttpHealth } from "../lib/api";
+
+export function useHttpHealth() {
+  return useSyncExternalStore(subscribeHttpHealth, getHttpHealth, getHttpHealth);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -115,3 +115,118 @@ export function wsUrl(path: string): string {
   }
   return `${r.wsProto}//${r.host}${path}`;
 }
+
+// ────────────────────────────────────────────────────────────────────────
+// apiFetch — circuit-breaker wrapper around fetch.
+//
+// Why: when host is unreachable (LAN down, Chrome PNA blocking HTTP from an
+// HTTPS context, DNS gone) the dashboard's six pollers will fire thousands of
+// requests/minute, all failing silently. apiFetch trips a circuit after N
+// consecutive failures and short-circuits further calls for OPEN_MS, with one
+// half-open probe to test recovery. Health is exposed so the UI can banner.
+// ────────────────────────────────────────────────────────────────────────
+
+const FAIL_THRESHOLD = 5;
+const OPEN_MS = 30_000;
+
+type Health = {
+  healthy: boolean;          // false once circuit trips
+  consecutiveFails: number;
+  openUntil: number;         // timestamp; 0 when closed
+  lastError: string | null;
+};
+
+let healthSnapshot: Health = { healthy: true, consecutiveFails: 0, openUntil: 0, lastError: null };
+const listeners = new Set<() => void>();
+
+function commit(next: Partial<Health>) {
+  const merged = { ...healthSnapshot, ...next };
+  if (merged.healthy === healthSnapshot.healthy
+      && merged.consecutiveFails === healthSnapshot.consecutiveFails
+      && merged.openUntil === healthSnapshot.openUntil
+      && merged.lastError === healthSnapshot.lastError) return;
+  healthSnapshot = merged;
+  listeners.forEach(l => l());
+}
+
+export function getHttpHealth(): Health {
+  return healthSnapshot;
+}
+
+export function subscribeHttpHealth(cb: () => void): () => void {
+  listeners.add(cb);
+  return () => { listeners.delete(cb); };
+}
+
+/** Force-close the circuit (e.g. after user changes host). */
+export function resetHttpHealth(): void {
+  commit({ healthy: true, consecutiveFails: 0, openUntil: 0, lastError: null });
+}
+
+// Is the active host private (LAN / localhost / .local)?
+// Chrome 142+ requires targetAddressSpace: 'local' on such fetches from HTTPS.
+function isPrivateHost(): boolean {
+  const r = resolveHost();
+  if (!r) return false;
+  const host = r.host.split(":")[0].toLowerCase();
+  if (host === "localhost" || host === "127.0.0.1" || host.endsWith(".local")) return true;
+  if (/^10\./.test(host)) return true;
+  if (/^192\.168\./.test(host)) return true;
+  if (/^172\.(1[6-9]|2\d|3[01])\./.test(host)) return true;
+  return false;
+}
+
+/**
+ * Drop-in fetch wrapper. Same signature, plus:
+ *   - Trips a circuit breaker after FAIL_THRESHOLD consecutive failures
+ *   - Adds targetAddressSpace: 'local' for private-network hosts (Chrome PNA)
+ *   - While circuit is open, throws immediately (one probe per OPEN_MS allowed)
+ *
+ * Callers should still .catch — this never resolves on circuit-open.
+ */
+export async function apiFetch(path: string, init?: RequestInit): Promise<Response> {
+  const url = path.startsWith("http") ? path : apiUrl(path);
+  const now = Date.now();
+
+  // Circuit open: allow exactly one probe per OPEN_MS; reject the rest.
+  if (!healthSnapshot.healthy && now < healthSnapshot.openUntil) {
+    throw new Error("circuit_open");
+  }
+
+  // Chrome PNA: opt the request into the local-network address space when the
+  // active host is private. Older Chromes ignore the option; newer ones use it
+  // to drive the permission prompt instead of a hard block.
+  const finalInit: RequestInit & { targetAddressSpace?: "local" | "private" } = { ...init };
+  if (isPrivateHost()) {
+    finalInit.targetAddressSpace = "local";
+  }
+
+  try {
+    const res = await fetch(url, finalInit);
+    // 5xx is still a "real" failure for breaker purposes; 4xx is not.
+    if (res.status >= 500) throw new Error(`http_${res.status}`);
+    // Success → reset.
+    if (!healthSnapshot.healthy || healthSnapshot.consecutiveFails > 0) {
+      commit({ healthy: true, consecutiveFails: 0, openUntil: 0, lastError: null });
+    }
+    return res;
+  } catch (err) {
+    const fails = healthSnapshot.consecutiveFails + 1;
+    const msg = err instanceof Error ? err.message : String(err);
+    if (fails >= FAIL_THRESHOLD) {
+      commit({ healthy: false, consecutiveFails: fails, openUntil: now + OPEN_MS, lastError: msg });
+    } else {
+      commit({ consecutiveFails: fails, lastError: msg });
+    }
+    throw err;
+  }
+}
+
+/** Convenience: apiFetch + .json(), returns null on any failure. */
+export async function apiFetchJson<T = any>(path: string, init?: RequestInit): Promise<T | null> {
+  try {
+    const r = await apiFetch(path, init);
+    if (!r.ok) return null;
+    return await r.json() as T;
+  } catch { return null; }
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { persist, createJSONStorage, type StateStorage } from "zustand/middleware";
-import { apiUrl } from "./api";
+import { apiFetch } from "./api";
 
 export interface RecentEntry {
   name: string;
@@ -112,7 +112,7 @@ function flushWrite() {
   if (pendingWrite === null) return;
   const body = pendingWrite;
   pendingWrite = null;
-  fetch(apiUrl(`/api/ui-state`), {
+  apiFetch(`/api/ui-state`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body,
@@ -121,7 +121,7 @@ function flushWrite() {
 
 /** Sync server state into localStorage, then rehydrate Zustand. */
 function syncFromServer(name: string) {
-  fetch(apiUrl("/api/ui-state")).then(async (res) => {
+  apiFetch("/api/ui-state").then(async (res) => {
     if (!res.ok) return;
     const data = await res.json();
     if (!data || Object.keys(data).length === 0) return;
@@ -154,7 +154,7 @@ const hybridStorage: StateStorage = {
   },
   removeItem: (name) => {
     localStorage.removeItem(name);
-    fetch(apiUrl(`/api/ui-state`), {
+    apiFetch(`/api/ui-state`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: "{}",
@@ -167,7 +167,7 @@ let askSaveTimer: ReturnType<typeof setTimeout> | null = null;
 function persistAsks(asks: AskItem[]) {
   if (askSaveTimer) clearTimeout(askSaveTimer);
   askSaveTimer = setTimeout(() => {
-    fetch(apiUrl(`/api/asks`), {
+    apiFetch(`/api/asks`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(asks),
@@ -361,7 +361,7 @@ export const useFleetStore = create<FleetStore>()(
 
 // Load asks from server on startup
 setTimeout(() => {
-  fetch(apiUrl("/api/asks"))
+  apiFetch("/api/asks")
     .then((r) => r.json())
     .then((data: AskItem[]) => {
       if (Array.isArray(data) && data.length > 0) {


### PR DESCRIPTION
## Why

`https://god.buildwithoracle.com/#overview` was firing **3,473 blocked requests**. Root cause is three layers stacked:

1. **Browser** — Chrome Private Network Access blocks every HTTPS→HTTP-private request. User's stored \`?host=\` is plain HTTP, so all polls die before they leave.
2. **App** — Six pollers (capture at 300–2000ms, ui-state per keystroke, PIN endpoints, etc.) silently \`.catch(()=>{})\` every failure and keep retrying at full speed. No backoff, no circuit breaker, no \`AbortController\`, no dedupe.
3. **UX** — The recent stale-banner only watched WS \`connected\`. If WS opens but HTTP polls are all PNA-blocked, the banner never fires.

## What changes

- **\`apiFetch\` wrapper** in \`src/lib/api.ts\` — drop-in for \`fetch(apiUrl(...))\`. Counts consecutive failures; after **5** trips a circuit for **30 s**, short-circuiting further calls with a \`circuit_open\` error. One probe per window allowed to test recovery. Also sets \`targetAddressSpace: 'local'\` on private-network hosts so Chrome 142+ surfaces the LNA permission prompt instead of a hard block.
- **\`useHttpHealth\`** hook + \`subscribeHttpHealth\` exposes \`{healthy, consecutiveFails, openUntil, lastError}\` to React.
- **\`App.tsx\` banner** — now fires on \`(!ws after 8s) || !httpHealthy\` and explains the cause (PNA, 5xx storm, etc.). Disconnect button also calls \`resetHttpHealth\`.
- **Migrated the hot pollers**: \`OverviewGrid\`, \`MiniMonitor\`, \`HoverPreviewCard\`, \`VSAgentPanel\`, \`MiniPreview\`, \`PinLock\`, and \`store.ts\` (ui-state + asks) → \`apiFetch\`.

## Out of scope (deliberate)

- \`DashboardPro.tsx\`, \`useChatLog.ts\`, the unrouted \`iPadDashboard.tsx\` still call \`fetch(apiUrl(...))\` directly. Follow-up if they exhibit the same.

## Test plan

- [ ] Build locally — \`bun run build\` clean ✅
- [ ] Load \`https://god.buildwithoracle.com/#overview\` with stored HTTP host → request count caps at ~5–10 (not 3000+); red banner appears explaining circuit open
- [ ] Click **Disconnect** → returns to ConnectPage; health resets
- [ ] Set reachable HTTPS host → circuit closes, polling resumes