### PR TITLE
feat(cache): vendor cached() SWR client-cache layer from ui-oracle (Phase 1)

### DIFF
--- a/src/hooks/useFederationData.ts
+++ b/src/hooks/useFederationData.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback } from "react";
 import { useWebSocket } from "./useWebSocket";
 import { useMqtt } from "./useMqtt";
 import { apiUrl } from "../lib/api";
+import { cached } from "../lib/cache";
 import { useFederationStore } from "../components/federation/store";
 import { simulate } from "../components/federation/simulation";
 import type { AgentNode, AgentEdge, Particle } from "../components/federation/types";
@@ -64,7 +65,10 @@ export function useFederationData() {
       //   /api/feed?limit=200    — live event log (replaces the old /api/messages)
       //   /api/plugins           — optional, may 404 on stale pm2 (graceful degrade)
       const [config, fleetConfig, feed, pluginData] = await Promise.all([
-        fetch(apiUrl("/api/config")).then(r => r.json()).catch(() => null),
+        // Proof-of-use of the vendored SWR cache: /api/config is read-only and
+        // rarely changes → 60s fresh window, then stale-while-revalidate. Live
+        // updates still arrive via WebSocket, so no mutation path invalidates this.
+        cached("maw:config", 60_000, () => fetch(apiUrl("/api/config")).then(r => r.json()), { tag: "maw:federation" }).catch(() => null),
         fetch(apiUrl("/api/fleet-config")).then(r => r.json()).catch(() => null),
         fetch(apiUrl("/api/feed?limit=200")).then(r => r.json()).catch(() => null),
         fetch(apiUrl("/api/plugins")).then(r => r.json()).catch(() => null),

--- a/src/lib/cache/bus.ts
+++ b/src/lib/cache/bus.ts
@@ -1,0 +1,56 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// Simple pub/sub bus for cache invalidation. Components fire
+// `cacheBus.invalidate('menu')` after a write; cached-wrapped readers
+// listen and drop any entry whose tag matches.
+
+import type { InvalidationEvent } from './types';
+
+type Listener = (ev: InvalidationEvent) => void;
+
+class CacheBus {
+  private listeners = new Set<Listener>();
+
+  /** Fire an invalidation event for `tag`. Also mirrors to other tabs via storage event. */
+  invalidate(tag: string): void {
+    const ev: InvalidationEvent = { tag, at: Date.now() };
+    for (const fn of this.listeners) {
+      try { fn(ev); } catch { /* ignore */ }
+    }
+    // Cross-tab: bump a well-known localStorage key so other tabs' `storage`
+    // listeners can pick it up and re-broadcast locally.
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('oracle_cache_bus_v1', JSON.stringify(ev));
+      }
+    } catch { /* ignore */ }
+  }
+
+  on(fn: Listener): () => void {
+    this.listeners.add(fn);
+    return () => { this.listeners.delete(fn); };
+  }
+
+  /** Rebroadcast a cross-tab storage event locally. */
+  private replay(raw: string | null): void {
+    if (!raw) return;
+    try {
+      const ev = JSON.parse(raw) as InvalidationEvent;
+      if (!ev || typeof ev.tag !== 'string') return;
+      for (const fn of this.listeners) {
+        try { fn(ev); } catch { /* ignore */ }
+      }
+    } catch { /* ignore */ }
+  }
+
+  /** Wire `storage` event listener — call once at app start. */
+  attachCrossTab(): () => void {
+    if (typeof window === 'undefined') return () => {};
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'oracle_cache_bus_v1') this.replay(e.newValue);
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }
+}
+
+export const cacheBus = new CacheBus();

--- a/src/lib/cache/cached.ts
+++ b/src/lib/cache/cached.ts
@@ -1,0 +1,97 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// cached() — stale-while-revalidate wrapper around a fetcher.
+//   fresh (age < ttl)  → return cached, no refetch.
+//   stale (age ≥ ttl)  → return cached AND kick off a background refetch.
+//   missing / version mismatch → await fetcher, write, return.
+//   cacheBus.invalidate(tag) drops every entry with that tag.
+// Storage: auto (local if ≤50KB, else idb). Override via policy.store.
+
+import type { CacheEntry, CachePolicy } from './types';
+import { localStore, estimateBytes } from './local-store';
+import { idbStore } from './idb-store';
+import { cacheBus } from './bus';
+
+const SIZE_THRESHOLD_BYTES = 50 * 1024;
+
+function appVersion(): string {
+  try { return typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'; }
+  catch { return 'dev'; }
+}
+
+// tag → keys index (for O(1) tag invalidation); inflight map (de-dupes concurrent fetchers).
+const tagIndex = new Map<string, Set<string>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+cacheBus.on(async (ev) => {
+  const keys = tagIndex.get(ev.tag);
+  if (!keys || keys.size === 0) return;
+  const snapshot = Array.from(keys);
+  keys.clear();
+  for (const k of snapshot) {
+    try { await localStore.del(k); } catch { /* ignore */ }
+    try { await idbStore.del(k); } catch { /* ignore */ }
+    inflight.delete(k);
+  }
+});
+
+async function readEntry<T>(key: string): Promise<CacheEntry<T> | null> {
+  return (await localStore.get<T>(key)) ?? (await idbStore.get<T>(key));
+}
+
+async function writeEntry<T>(key: string, entry: CacheEntry<T>, policy: CachePolicy): Promise<void> {
+  if (policy.store === 'idb') { await idbStore.set(key, entry); return; }
+  if (policy.store === 'local') { await localStore.set(key, entry); return; }
+  if (estimateBytes(entry.data) > SIZE_THRESHOLD_BYTES) { await idbStore.set(key, entry); return; }
+  try { await localStore.set(key, entry); }
+  catch { await idbStore.set(key, entry); }
+}
+
+async function fetchAndStore<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): Promise<T> {
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const p = (async () => {
+    const data = await fetcher();
+    const entry: CacheEntry<T> = { v: appVersion(), ts: Date.now(), ttl: ttlMs, tag: policy.tag, data };
+    try { await writeEntry(key, entry, policy); } catch { /* ignore */ }
+    return data;
+  })();
+  inflight.set(key, p);
+  try { return await p; } finally { inflight.delete(key); }
+}
+
+function refreshInBackground<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): void {
+  if (inflight.has(key)) return;
+  const p = fetchAndStore(key, ttlMs, fetcher, policy).catch(() => { /* swallow */ });
+  inflight.set(key, p);
+  void p.finally(() => { inflight.delete(key); });
+}
+
+/** Wrap `fetcher` with stale-while-revalidate caching keyed by `key`. */
+export async function cached<T>(
+  key: string,
+  ttlMs: number,
+  fetcher: () => Promise<T>,
+  policy: CachePolicy = {},
+): Promise<T> {
+  if (policy.tag) {
+    let set = tagIndex.get(policy.tag);
+    if (!set) { set = new Set(); tagIndex.set(policy.tag, set); }
+    set.add(key);
+  }
+  if (ttlMs <= 0) return fetcher();
+
+  const entry = await readEntry<T>(key);
+  const v = appVersion();
+  if (entry && entry.v === v) {
+    if (Date.now() - entry.ts < ttlMs) return entry.data;
+    refreshInBackground(key, ttlMs, fetcher, policy);
+    return entry.data;
+  }
+  return fetchAndStore(key, ttlMs, fetcher, policy);
+}
+
+/** Test-only reset. */
+export function __resetCachedForTests(): void {
+  tagIndex.clear();
+  inflight.clear();
+}

--- a/src/lib/cache/idb-store.ts
+++ b/src/lib/cache/idb-store.ts
@@ -1,0 +1,95 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// IndexedDB adapter for the client cache — used for larger payloads
+// (>50KB) that would bloat localStorage. Single object-store keyed by
+// string. Gracefully no-ops when IndexedDB is unavailable.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const DB_NAME = 'oracle_cache_v1';
+const STORE = 'entries';
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve) => {
+    try {
+      if (typeof indexedDB === 'undefined') { resolve(null); return; }
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+      req.onblocked = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+  return dbPromise;
+}
+
+function tx(db: IDBDatabase, mode: IDBTransactionMode): IDBObjectStore {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function promisify<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export const idbStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const db = await openDb();
+    if (!db) return null;
+    try {
+      const val = await promisify<unknown>(tx(db, 'readonly').get(key));
+      if (!val || typeof val !== 'object') return null;
+      const e = val as CacheEntry<T>;
+      if (typeof e.ts !== 'number' || typeof e.ttl !== 'number') return null;
+      return e;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').put(entry, key)); } catch {
+      throw new Error('idbStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').delete(key)); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const db = await openDb();
+    if (!db) return [];
+    try {
+      const req = tx(db, 'readonly').getAllKeys();
+      const arr = await promisify<IDBValidKey[]>(req);
+      return arr.map((k) => String(k));
+    } catch {
+      return [];
+    }
+  },
+
+  async clear(): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').clear()); } catch { /* ignore */ }
+  },
+};
+
+/** Reset the module singleton — test-only; not exported from the barrel. */
+export function __resetIdbForTests(): void {
+  dbPromise = null;
+}

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,0 +1,7 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// Barrel for the client cache module.
+export { cached } from './cached';
+export { cacheBus } from './bus';
+export { localStore } from './local-store';
+export { idbStore } from './idb-store';
+export type { CacheEntry, CachePolicy, InvalidationEvent, CacheStore } from './types';

--- a/src/lib/cache/local-store.ts
+++ b/src/lib/cache/local-store.ts
@@ -1,0 +1,88 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// localStorage adapter for the client cache.
+//
+// Keys are namespaced under `oracle_cache/v1:` so the store is easy to spot
+// in devtools and can be wiped atomically via `clear()`.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const PREFIX = 'oracle_cache/v1:';
+
+function storage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export const localStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const ls = storage();
+    if (!ls) return null;
+    try {
+      const raw = ls.getItem(PREFIX + key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as CacheEntry<T>;
+      if (!parsed || typeof parsed.ts !== 'number' || typeof parsed.ttl !== 'number') return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      ls.setItem(PREFIX + key, JSON.stringify(entry));
+    } catch {
+      // Quota exceeded or other failure — swallow; caller may fall back to idb.
+      throw new Error('localStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try { ls.removeItem(PREFIX + key); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const ls = storage();
+    if (!ls) return [];
+    const out: string[] = [];
+    try {
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) out.push(k.slice(PREFIX.length));
+      }
+    } catch { /* ignore */ }
+    return out;
+  },
+
+  async clear(): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      const doomed: string[] = [];
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) doomed.push(k);
+      }
+      for (const k of doomed) ls.removeItem(k);
+    } catch { /* ignore */ }
+  },
+};
+
+/** Estimate the byte size of a value once JSON-encoded. */
+export function estimateBytes(value: unknown): number {
+  try {
+    return new Blob([JSON.stringify(value)]).size;
+  } catch {
+    try { return JSON.stringify(value).length * 2; } catch { return 0; }
+  }
+}
+
+export const LOCAL_STORE_PREFIX = PREFIX;

--- a/src/lib/cache/types.ts
+++ b/src/lib/cache/types.ts
@@ -1,0 +1,35 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// Client-side API cache — shared types.
+
+export interface CacheEntry<T = unknown> {
+  /** App build version (from __APP_VERSION__) at write time. */
+  v: string;
+  /** ISO epoch ms when this entry was written. */
+  ts: number;
+  /** TTL in ms — entry is fresh while `now - ts < ttl`. */
+  ttl: number;
+  /** Invalidation tag (optional). */
+  tag?: string;
+  /** The cached value. */
+  data: T;
+}
+
+export interface CachePolicy {
+  /** Invalidation tag for bulk clear via cacheBus. */
+  tag?: string;
+  /** Force a specific backing store. Default: auto — local first, idb if payload > 50KB. */
+  store?: 'local' | 'idb';
+}
+
+export interface InvalidationEvent {
+  tag: string;
+  at: number;
+}
+
+export interface CacheStore {
+  get<T>(key: string): Promise<CacheEntry<T> | null>;
+  set<T>(key: string, entry: CacheEntry<T>): Promise<void>;
+  del(key: string): Promise<void>;
+  keys(): Promise<string[]>;
+  clear(): Promise<void>;
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,4 @@
 
 declare const __MAW_VERSION__: string;
 declare const __MAW_BUILD__: string;
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,16 @@ import pkg from "./package.json";
 
 const MAW_HTTP = process.env.VITE_MAW_URL ?? "http://localhost:3456";
 const MAW_WS = MAW_HTTP.replace(/^http/, "ws");
+const MAW_BUILD = new Date().toLocaleString("sv-SE", { timeZone: "Asia/Bangkok", dateStyle: "short", timeStyle: "short" });
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
   define: {
     __MAW_VERSION__: JSON.stringify(pkg.version),
-    __MAW_BUILD__: JSON.stringify(new Date().toLocaleString("sv-SE", { timeZone: "Asia/Bangkok", dateStyle: "short", timeStyle: "short" })),
+    __MAW_BUILD__: JSON.stringify(MAW_BUILD),
+    // Consumed by the vendored cache layer (src/lib/cache) to version-bust entries.
+    // version+build → busts on every deploy, not just on a package version bump.
+    __APP_VERSION__: JSON.stringify(`${pkg.version}+${MAW_BUILD}`),
   },
   root: ".",
   base: "/",


### PR DESCRIPTION
## Phase 1 — vendor `cached()` SWR client-cache layer into maw-ui

Foundation + one proof-of-use, per Labubu exec-dispatch (Boss-approved). **Not** a sweeping refactor — a reviewable seam for later phases.

### What
- **Vendor 6 files** from `Soul-Brews-Studio/ui-oracle` `shared-ui/src/cache` @ `e4dd6a7` into `src/lib/cache/` (`types, bus, local-store, idb-store, cached, index`). Byte-identical + 1-line BUSL-1.1 provenance header each → future re-sync is a diff, not archaeology. **Zero runtime deps, no React coupling.**
- **Wire version global**: keep vendored `cached.ts` pristine; add `__APP_VERSION__ = ${pkg.version}+${MAW_BUILD}` to `vite.config.ts` define + `declare const __APP_VERSION__` in `vite-env.d.ts`. Using version+build means cache entries **version-bust on every deploy** (correctness behavior the integration guide flagged).
- **Proof-of-use**: wrap the read-only `/api/config` fetch in `useFederationData.ts` with `cached("maw:config", 60_000, …, { tag: "maw:federation" })`. Kept existing `.catch(()=>null)` graceful-degrade.

### Guardrails honored
- No mutation/POST/auth/WebSocket path cached. No `cacheBus.invalidate` wired — `/api/config` has no mutation (updates arrive via WebSocket, independent of this entry).
- Not deployed to `/opt/maw-dashboard`.

### Verification
- `bunx tsc --noEmit` → **exit 0** (independently re-run by Labubu).
- `bun run build` → **exit 0** (`✓ built in 7.30s`; pre-existing three.module chunk-size warning unrelated). Bundle confirms `__APP_VERSION__` injection.
- No test script in maw-ui → none to run.

### Deliberately left for Phase 2
- Broaden `cached()` to other read-only GETs (fleet-config / plugins).
- `cacheBus.attachCrossTab()` at app start for cross-tab invalidation.
- Port the vitest suite from ui-oracle (needs `setup.ts` version shim).

### Provenance
Extraction report: `labubu-oracle/ψ/learn/Soul-Brews-Studio/ui-oracle/2026-06-03/0013_*.md`. Source license: BUSL-1.1 (internal use).

Implemented by **Echo Oracle** 📚 (MAW UI territory) · dispatched + verified by **Labubu Oracle** 🔮

🤖 Generated with [Claude Code](https://claude.com/claude-code)