### PR TITLE
feat(cache): Phase 2 — broaden cached() + cross-tab + test suite (stacked on #56)

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "bun test src/lib/cache/__tests__"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/src/components/WorktreeView.tsx
+++ b/src/components/WorktreeView.tsx
@@ -1,5 +1,10 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiUrl } from "../lib/api";
+import { cached, cacheBus } from "../lib/cache";
+
+const WORKTREE_CACHE_KEY = "maw-ui:worktrees:v1";
+const WORKTREE_CACHE_TAG = "worktrees";
+const WORKTREE_TTL_MS = 15_000;
 
 interface WorktreeInfo {
   path: string;
@@ -29,8 +34,12 @@ export function WorktreeView() {
     setLoading(true);
     setError("");
     try {
-      const res = await fetch(apiUrl("/api/worktrees"));
-      const data = await res.json();
+      const data = await cached(
+        WORKTREE_CACHE_KEY,
+        WORKTREE_TTL_MS,
+        () => fetch(apiUrl("/api/worktrees")).then((r) => r.json()),
+        { tag: WORKTREE_CACHE_TAG },
+      );
       if (Array.isArray(data)) {
         setWorktrees(data);
       } else if (data.error) {
@@ -56,6 +65,7 @@ export function WorktreeView() {
       if (data.ok) {
         setLogs((prev) => ({ ...prev, [wt.path]: data.log }));
         // Refresh after cleanup
+        cacheBus.invalidate(WORKTREE_CACHE_TAG);
         setTimeout(fetchWorktrees, 500);
       } else {
         setLogs((prev) => ({ ...prev, [wt.path]: [`Error: ${data.error}`] }));

--- a/src/hooks/useFederationData.ts
+++ b/src/hooks/useFederationData.ts
@@ -69,9 +69,14 @@ export function useFederationData() {
         // rarely changes → 60s fresh window, then stale-while-revalidate. Live
         // updates still arrive via WebSocket, so no mutation path invalidates this.
         cached("maw:config", 60_000, () => fetch(apiUrl("/api/config")).then(r => r.json()), { tag: "maw:federation" }).catch(() => null),
-        fetch(apiUrl("/api/fleet-config")).then(r => r.json()).catch(() => null),
+        // /api/fleet-config — fleet entries (sync_peers + budded_from). Read-only,
+        // changes only when a node is budded/retired → 60s fresh, then SWR.
+        cached("maw:fleet-config", 60_000, () => fetch(apiUrl("/api/fleet-config")).then(r => r.json()), { tag: "maw:fleet" }).catch(() => null),
+        // /api/feed is the live event log — deliberately NOT cached (mutates every event).
         fetch(apiUrl("/api/feed?limit=200")).then(r => r.json()).catch(() => null),
-        fetch(apiUrl("/api/plugins")).then(r => r.json()).catch(() => null),
+        // /api/plugins — installed-plugin list, changes only on pm2 redeploy →
+        // longer 300s fresh window, then SWR.
+        cached("maw:plugins", 300_000, () => fetch(apiUrl("/api/plugins")).then(r => r.json()), { tag: "maw:plugins" }).catch(() => null),
       ]);
 
       // Identity: which maw-js node is this lens reading? (config.node = "oracle-world", "white", ...)

--- a/src/hooks/useFederationData.ts
+++ b/src/hooks/useFederationData.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback } from "react";
 import { useWebSocket } from "./useWebSocket";
 import { useMqtt } from "./useMqtt";
 import { apiUrl } from "../lib/api";
+import { cached } from "../lib/cache";
 import { useFederationStore } from "../components/federation/store";
 import { simulate } from "../components/federation/simulation";
 import type { AgentNode, AgentEdge, Particle } from "../components/federation/types";
@@ -64,7 +65,10 @@ export function useFederationData() {
       //   /api/feed?limit=200    — live event log (replaces the old /api/messages)
       //   /api/plugins           — optional, may 404 on stale pm2 (graceful degrade)
       const [config, fleetConfig, feed, pluginData] = await Promise.all([
-        fetch(apiUrl("/api/config")).then(r => r.json()).catch(() => null),
+        // Proof-of-use of the vendored SWR cache: /api/config is read-only and
+        // rarely changes → 60s fresh window, then stale-while-revalidate. Live
+        // updates still arrive via WebSocket, so no mutation path invalidates this.
+        cached("maw:config", 60_000, () => fetch(apiUrl("/api/config")).then(r => r.json()), { tag: "maw:federation" }).catch(() => null),
         fetch(apiUrl("/api/fleet-config")).then(r => r.json()).catch(() => null),
         fetch(apiUrl("/api/feed?limit=200")).then(r => r.json()).catch(() => null),
         fetch(apiUrl("/api/plugins")).then(r => r.json()).catch(() => null),

--- a/src/lib/cache/__tests__/bus.test.ts
+++ b/src/lib/cache/__tests__/bus.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'bun:test';
+import { installDomMocks } from './setup';
+
+installDomMocks();
+
+const { cacheBus } = await import('../bus');
+
+describe('cacheBus', () => {
+  it('delivers invalidation events to listeners', () => {
+    const events: string[] = [];
+    const off = cacheBus.on((ev) => { events.push(ev.tag); });
+    cacheBus.invalidate('menu');
+    cacheBus.invalidate('stats');
+    off();
+    cacheBus.invalidate('menu'); // post-off: should not deliver
+    expect(events).toEqual(['menu', 'stats']);
+  });
+
+  it('mirrors events to localStorage for cross-tab', () => {
+    cacheBus.invalidate('oracles');
+    const raw = (globalThis as unknown as { localStorage: Storage }).localStorage.getItem('oracle_cache_bus_v1');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.tag).toBe('oracles');
+    expect(typeof parsed.at).toBe('number');
+  });
+
+  it('attachCrossTab returns an unsubscribe function', () => {
+    const off = cacheBus.attachCrossTab();
+    expect(typeof off).toBe('function');
+    off();
+  });
+});

--- a/src/lib/cache/__tests__/cached.test.ts
+++ b/src/lib/cache/__tests__/cached.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { installDomMocks, resetDomMocks } from './setup';
+
+installDomMocks('v1.0.0+test');
+
+const { cached, __resetCachedForTests } = await import('../cached');
+const { cacheBus } = await import('../bus');
+const { localStore } = await import('../local-store');
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+describe('cached()', () => {
+  beforeEach(async () => {
+    resetDomMocks();
+    __resetCachedForTests();
+    await localStore.clear();
+  });
+
+  it('fetches on first call and caches', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return { n: calls }; };
+    const a = await cached('k', 10_000, fetcher);
+    const b = await cached('k', 10_000, fetcher);
+    expect(a.n).toBe(1);
+    expect(b.n).toBe(1); // served from cache
+    expect(calls).toBe(1);
+  });
+
+  it('re-fetches after TTL expires (stale-while-revalidate)', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    const v1 = await cached('swr', 5, fetcher);
+    expect(v1).toBe(1);
+    await sleep(10);
+    // Stale: returns cached value immediately but triggers background refetch.
+    const v2 = await cached('swr', 5, fetcher);
+    expect(v2).toBe(1);
+    // Wait for background refetch to finish.
+    await sleep(20);
+    const v3 = await cached('swr', 10_000, fetcher);
+    expect(v3).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  it('version mismatch invalidates entry', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('vk', 10_000, fetcher);
+    expect(calls).toBe(1);
+
+    // Simulate a new build version.
+    (globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = 'v2.0.0+test';
+    const v = await cached('vk', 10_000, fetcher);
+    expect(v).toBe(2);
+    expect(calls).toBe(2);
+
+    (globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = 'v1.0.0+test';
+  });
+
+  it('cacheBus.invalidate(tag) drops tagged entries', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('menu-a', 10_000, fetcher, { tag: 'menu' });
+    await cached('menu-b', 10_000, fetcher, { tag: 'menu' });
+    expect(calls).toBe(2);
+
+    cacheBus.invalidate('menu');
+    // Allow async listeners to run.
+    await sleep(5);
+
+    const v = await cached('menu-a', 10_000, fetcher, { tag: 'menu' });
+    expect(v).toBe(3);
+  });
+
+  it('ttl <= 0 bypasses the cache', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('nocache', 0, fetcher);
+    await cached('nocache', 0, fetcher);
+    expect(calls).toBe(2);
+  });
+
+  it('de-dupes concurrent initial fetches', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; await sleep(20); return 'x'; };
+    const [a, b, c] = await Promise.all([
+      cached('dedup', 10_000, fetcher),
+      cached('dedup', 10_000, fetcher),
+      cached('dedup', 10_000, fetcher),
+    ]);
+    expect(a).toBe('x');
+    expect(b).toBe('x');
+    expect(c).toBe('x');
+    expect(calls).toBe(1);
+  });
+});

--- a/src/lib/cache/__tests__/local-store.test.ts
+++ b/src/lib/cache/__tests__/local-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { installDomMocks, resetDomMocks } from './setup';
+
+installDomMocks();
+
+// Import after mocks are installed.
+const { localStore, estimateBytes } = await import('../local-store');
+
+describe('localStore', () => {
+  beforeEach(() => { resetDomMocks(); });
+
+  it('round-trips an entry', async () => {
+    await localStore.set('k1', { v: 'v0', ts: 1, ttl: 1000, data: { hello: 'world' } });
+    const got = await localStore.get<{ hello: string }>('k1');
+    expect(got?.data.hello).toBe('world');
+    expect(got?.ttl).toBe(1000);
+  });
+
+  it('returns null for missing keys', async () => {
+    expect(await localStore.get('missing')).toBeNull();
+  });
+
+  it('deletes entries', async () => {
+    await localStore.set('k2', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.del('k2');
+    expect(await localStore.get('k2')).toBeNull();
+  });
+
+  it('keys() returns only cache-prefixed keys', async () => {
+    await localStore.set('a', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.set('b', { v: 'v0', ts: 1, ttl: 1, data: 2 });
+    const keys = await localStore.keys();
+    expect(keys.sort()).toEqual(['a', 'b']);
+  });
+
+  it('clear() removes all cache entries', async () => {
+    await localStore.set('a', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.clear();
+    expect((await localStore.keys()).length).toBe(0);
+  });
+
+  it('estimateBytes grows with payload', () => {
+    expect(estimateBytes('x')).toBeGreaterThan(0);
+    expect(estimateBytes('xxxxxxxxxx')).toBeGreaterThan(estimateBytes('x'));
+  });
+});

--- a/src/lib/cache/__tests__/setup.ts
+++ b/src/lib/cache/__tests__/setup.ts
@@ -1,0 +1,35 @@
+// Minimal DOM-ish mocks for bun:test — only what the cache module touches.
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+  get length() { return this.store.size; }
+  key(i: number): string | null {
+    return Array.from(this.store.keys())[i] ?? null;
+  }
+  getItem(k: string): string | null { return this.store.get(k) ?? null; }
+  setItem(k: string, v: string): void { this.store.set(k, String(v)); }
+  removeItem(k: string): void { this.store.delete(k); }
+  clear(): void { this.store.clear(); }
+}
+
+export function installDomMocks(version = 'v0.0.0+test'): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.__APP_VERSION__ = version;
+  g.localStorage = new MemoryStorage();
+  g.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  g.indexedDB = undefined; // force localStore path; idb tested separately
+  g.Blob = class MockBlob {
+    size: number;
+    constructor(parts: unknown[]) {
+      this.size = parts.reduce<number>((sum, p) => sum + (typeof p === 'string' ? p.length : 0), 0);
+    }
+  } as unknown as typeof Blob;
+}
+
+export function resetDomMocks(): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  (g.localStorage as MemoryStorage | undefined)?.clear();
+}

--- a/src/lib/cache/bus.ts
+++ b/src/lib/cache/bus.ts
@@ -1,0 +1,56 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// Simple pub/sub bus for cache invalidation. Components fire
+// `cacheBus.invalidate('menu')` after a write; cached-wrapped readers
+// listen and drop any entry whose tag matches.
+
+import type { InvalidationEvent } from './types';
+
+type Listener = (ev: InvalidationEvent) => void;
+
+class CacheBus {
+  private listeners = new Set<Listener>();
+
+  /** Fire an invalidation event for `tag`. Also mirrors to other tabs via storage event. */
+  invalidate(tag: string): void {
+    const ev: InvalidationEvent = { tag, at: Date.now() };
+    for (const fn of this.listeners) {
+      try { fn(ev); } catch { /* ignore */ }
+    }
+    // Cross-tab: bump a well-known localStorage key so other tabs' `storage`
+    // listeners can pick it up and re-broadcast locally.
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('oracle_cache_bus_v1', JSON.stringify(ev));
+      }
+    } catch { /* ignore */ }
+  }
+
+  on(fn: Listener): () => void {
+    this.listeners.add(fn);
+    return () => { this.listeners.delete(fn); };
+  }
+
+  /** Rebroadcast a cross-tab storage event locally. */
+  private replay(raw: string | null): void {
+    if (!raw) return;
+    try {
+      const ev = JSON.parse(raw) as InvalidationEvent;
+      if (!ev || typeof ev.tag !== 'string') return;
+      for (const fn of this.listeners) {
+        try { fn(ev); } catch { /* ignore */ }
+      }
+    } catch { /* ignore */ }
+  }
+
+  /** Wire `storage` event listener — call once at app start. */
+  attachCrossTab(): () => void {
+    if (typeof window === 'undefined') return () => {};
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'oracle_cache_bus_v1') this.replay(e.newValue);
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }
+}
+
+export const cacheBus = new CacheBus();

--- a/src/lib/cache/cached.ts
+++ b/src/lib/cache/cached.ts
@@ -1,0 +1,97 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// cached() — stale-while-revalidate wrapper around a fetcher.
+//   fresh (age < ttl)  → return cached, no refetch.
+//   stale (age ≥ ttl)  → return cached AND kick off a background refetch.
+//   missing / version mismatch → await fetcher, write, return.
+//   cacheBus.invalidate(tag) drops every entry with that tag.
+// Storage: auto (local if ≤50KB, else idb). Override via policy.store.
+
+import type { CacheEntry, CachePolicy } from './types';
+import { localStore, estimateBytes } from './local-store';
+import { idbStore } from './idb-store';
+import { cacheBus } from './bus';
+
+const SIZE_THRESHOLD_BYTES = 50 * 1024;
+
+function appVersion(): string {
+  try { return typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'; }
+  catch { return 'dev'; }
+}
+
+// tag → keys index (for O(1) tag invalidation); inflight map (de-dupes concurrent fetchers).
+const tagIndex = new Map<string, Set<string>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+cacheBus.on(async (ev) => {
+  const keys = tagIndex.get(ev.tag);
+  if (!keys || keys.size === 0) return;
+  const snapshot = Array.from(keys);
+  keys.clear();
+  for (const k of snapshot) {
+    try { await localStore.del(k); } catch { /* ignore */ }
+    try { await idbStore.del(k); } catch { /* ignore */ }
+    inflight.delete(k);
+  }
+});
+
+async function readEntry<T>(key: string): Promise<CacheEntry<T> | null> {
+  return (await localStore.get<T>(key)) ?? (await idbStore.get<T>(key));
+}
+
+async function writeEntry<T>(key: string, entry: CacheEntry<T>, policy: CachePolicy): Promise<void> {
+  if (policy.store === 'idb') { await idbStore.set(key, entry); return; }
+  if (policy.store === 'local') { await localStore.set(key, entry); return; }
+  if (estimateBytes(entry.data) > SIZE_THRESHOLD_BYTES) { await idbStore.set(key, entry); return; }
+  try { await localStore.set(key, entry); }
+  catch { await idbStore.set(key, entry); }
+}
+
+async function fetchAndStore<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): Promise<T> {
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const p = (async () => {
+    const data = await fetcher();
+    const entry: CacheEntry<T> = { v: appVersion(), ts: Date.now(), ttl: ttlMs, tag: policy.tag, data };
+    try { await writeEntry(key, entry, policy); } catch { /* ignore */ }
+    return data;
+  })();
+  inflight.set(key, p);
+  try { return await p; } finally { inflight.delete(key); }
+}
+
+function refreshInBackground<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): void {
+  if (inflight.has(key)) return;
+  const p = fetchAndStore(key, ttlMs, fetcher, policy).catch(() => { /* swallow */ });
+  inflight.set(key, p);
+  void p.finally(() => { inflight.delete(key); });
+}
+
+/** Wrap `fetcher` with stale-while-revalidate caching keyed by `key`. */
+export async function cached<T>(
+  key: string,
+  ttlMs: number,
+  fetcher: () => Promise<T>,
+  policy: CachePolicy = {},
+): Promise<T> {
+  if (policy.tag) {
+    let set = tagIndex.get(policy.tag);
+    if (!set) { set = new Set(); tagIndex.set(policy.tag, set); }
+    set.add(key);
+  }
+  if (ttlMs <= 0) return fetcher();
+
+  const entry = await readEntry<T>(key);
+  const v = appVersion();
+  if (entry && entry.v === v) {
+    if (Date.now() - entry.ts < ttlMs) return entry.data;
+    refreshInBackground(key, ttlMs, fetcher, policy);
+    return entry.data;
+  }
+  return fetchAndStore(key, ttlMs, fetcher, policy);
+}
+
+/** Test-only reset. */
+export function __resetCachedForTests(): void {
+  tagIndex.clear();
+  inflight.clear();
+}

--- a/src/lib/cache/idb-store.ts
+++ b/src/lib/cache/idb-store.ts
@@ -1,0 +1,95 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// IndexedDB adapter for the client cache — used for larger payloads
+// (>50KB) that would bloat localStorage. Single object-store keyed by
+// string. Gracefully no-ops when IndexedDB is unavailable.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const DB_NAME = 'oracle_cache_v1';
+const STORE = 'entries';
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve) => {
+    try {
+      if (typeof indexedDB === 'undefined') { resolve(null); return; }
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+      req.onblocked = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+  return dbPromise;
+}
+
+function tx(db: IDBDatabase, mode: IDBTransactionMode): IDBObjectStore {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function promisify<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export const idbStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const db = await openDb();
+    if (!db) return null;
+    try {
+      const val = await promisify<unknown>(tx(db, 'readonly').get(key));
+      if (!val || typeof val !== 'object') return null;
+      const e = val as CacheEntry<T>;
+      if (typeof e.ts !== 'number' || typeof e.ttl !== 'number') return null;
+      return e;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').put(entry, key)); } catch {
+      throw new Error('idbStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').delete(key)); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const db = await openDb();
+    if (!db) return [];
+    try {
+      const req = tx(db, 'readonly').getAllKeys();
+      const arr = await promisify<IDBValidKey[]>(req);
+      return arr.map((k) => String(k));
+    } catch {
+      return [];
+    }
+  },
+
+  async clear(): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').clear()); } catch { /* ignore */ }
+  },
+};
+
+/** Reset the module singleton — test-only; not exported from the barrel. */
+export function __resetIdbForTests(): void {
+  dbPromise = null;
+}

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,0 +1,7 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// Barrel for the client cache module.
+export { cached } from './cached';
+export { cacheBus } from './bus';
+export { localStore } from './local-store';
+export { idbStore } from './idb-store';
+export type { CacheEntry, CachePolicy, InvalidationEvent, CacheStore } from './types';

--- a/src/lib/cache/local-store.ts
+++ b/src/lib/cache/local-store.ts
@@ -1,0 +1,88 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// localStorage adapter for the client cache.
+//
+// Keys are namespaced under `oracle_cache/v1:` so the store is easy to spot
+// in devtools and can be wiped atomically via `clear()`.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const PREFIX = 'oracle_cache/v1:';
+
+function storage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export const localStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const ls = storage();
+    if (!ls) return null;
+    try {
+      const raw = ls.getItem(PREFIX + key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as CacheEntry<T>;
+      if (!parsed || typeof parsed.ts !== 'number' || typeof parsed.ttl !== 'number') return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      ls.setItem(PREFIX + key, JSON.stringify(entry));
+    } catch {
+      // Quota exceeded or other failure — swallow; caller may fall back to idb.
+      throw new Error('localStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try { ls.removeItem(PREFIX + key); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const ls = storage();
+    if (!ls) return [];
+    const out: string[] = [];
+    try {
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) out.push(k.slice(PREFIX.length));
+      }
+    } catch { /* ignore */ }
+    return out;
+  },
+
+  async clear(): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      const doomed: string[] = [];
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) doomed.push(k);
+      }
+      for (const k of doomed) ls.removeItem(k);
+    } catch { /* ignore */ }
+  },
+};
+
+/** Estimate the byte size of a value once JSON-encoded. */
+export function estimateBytes(value: unknown): number {
+  try {
+    return new Blob([JSON.stringify(value)]).size;
+  } catch {
+    try { return JSON.stringify(value).length * 2; } catch { return 0; }
+  }
+}
+
+export const LOCAL_STORE_PREFIX = PREFIX;

--- a/src/lib/cache/types.ts
+++ b/src/lib/cache/types.ts
@@ -1,0 +1,35 @@
+// Vendored from Soul-Brews-Studio/ui-oracle packages/shared-ui/src/cache @ a1d160c — BUSL-1.1 (extract: ψ 2026-06-03)
+// Client-side API cache — shared types.
+
+export interface CacheEntry<T = unknown> {
+  /** App build version (from __APP_VERSION__) at write time. */
+  v: string;
+  /** ISO epoch ms when this entry was written. */
+  ts: number;
+  /** TTL in ms — entry is fresh while `now - ts < ttl`. */
+  ttl: number;
+  /** Invalidation tag (optional). */
+  tag?: string;
+  /** The cached value. */
+  data: T;
+}
+
+export interface CachePolicy {
+  /** Invalidation tag for bulk clear via cacheBus. */
+  tag?: string;
+  /** Force a specific backing store. Default: auto — local first, idb if payload > 50KB. */
+  store?: 'local' | 'idb';
+}
+
+export interface InvalidationEvent {
+  tag: string;
+  at: number;
+}
+
+export interface CacheStore {
+  get<T>(key: string): Promise<CacheEntry<T> | null>;
+  set<T>(key: string, entry: CacheEntry<T>): Promise<void>;
+  del(key: string): Promise<void>;
+  keys(): Promise<string[]>;
+  clear(): Promise<void>;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,14 @@ import "./index.css";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { PinLock } from "./components/PinLock";
+import { cacheBus } from "./lib/cache";
+
+// Cross-tab cache invalidation: a write in one tab drops matching cache
+// entries in every open tab. attachCrossTab() self-guards `typeof window`,
+// so the browser check below is belt-and-suspenders for SSR/test contexts.
+if (typeof window !== "undefined") {
+  cacheBus.attachCrossTab();
+}
 
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,3 +2,4 @@
 
 declare const __MAW_VERSION__: string;
 declare const __MAW_BUILD__: string;
+declare const __APP_VERSION__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,12 +6,16 @@ import pkg from "./package.json";
 
 const MAW_HTTP = process.env.VITE_MAW_URL ?? "http://localhost:3456";
 const MAW_WS = MAW_HTTP.replace(/^http/, "ws");
+const MAW_BUILD = new Date().toLocaleString("sv-SE", { timeZone: "Asia/Bangkok", dateStyle: "short", timeStyle: "short" });
 
 export default defineConfig({
   plugins: [tailwindcss(), react()],
   define: {
     __MAW_VERSION__: JSON.stringify(pkg.version),
-    __MAW_BUILD__: JSON.stringify(new Date().toLocaleString("sv-SE", { timeZone: "Asia/Bangkok", dateStyle: "short", timeStyle: "short" })),
+    __MAW_BUILD__: JSON.stringify(MAW_BUILD),
+    // Consumed by the vendored cache layer (src/lib/cache) to version-bust entries.
+    // version+build → busts on every deploy, not just on a package version bump.
+    __APP_VERSION__: JSON.stringify(`${pkg.version}+${MAW_BUILD}`),
   },
   root: ".",
   base: "/",


### PR DESCRIPTION
## Phase 2 — broaden `cached()`, cross-tab invalidation, test suite

Builds on #56 (Phase 1: vendored `cached()` SWR layer). All three Phase-2 items landed — none deferred.

> **⚠️ Stacked on #56.** This branch is off `feat/cached-swr-layer`, so the diff currently includes Phase 1's commit too. **Merge #56 first** — this then narrows to Phase 2 only (Echo confirms rebase is trivial: Phase 2 only adds lines in `useFederationData.ts` + new test files, zero overlap).

### Item A — broaden to 2 more read-only GETs (`useFederationData.ts`)
| Endpoint | key | TTL | tag | rationale |
|---|---|---|---|---|
| `/api/fleet-config` | `maw:fleet-config` | 60s | `maw:fleet` | changes only on bud/retire |
| `/api/plugins` | `maw:plugins` | 300s | `maw:plugins` | changes only on pm2 redeploy → longer window |

Both keep `.catch(()=>null)` graceful-degrade. `/api/feed` left **uncached** (live event log). No POST/auth/WebSocket touched.

### Item B — cross-tab invalidation
`cacheBus.attachCrossTab()` wired once at app startup (`src/main.tsx`), browser-guarded. Invalidation in one tab now propagates to all open tabs.

### Item C — test suite (no prior test infra)
Lightest path: `bun test` (no new deps, no vitest/jest). Ported `{bus,cached,local-store}.test.ts` + `setup.ts` verbatim from ui-oracle `shared-ui/cache/__tests__`; `setup.ts` provides the `__APP_VERSION__` shim + DOM mocks. Scoped script to `src/lib/cache/__tests__`.

### Verification (independently re-run by Labubu)
- `bunx tsc --noEmit` → **exit 0**
- `bun run build` → **exit 0** (`✓ built in 5.09s`; pre-existing three.js chunk-size warning unrelated)
- `bun test src/lib/cache/__tests__` → **15 pass / 0 fail / 30 expect() calls**

7 files, +227/−3. Pushed to fork only — not on origin, not deployed.

Implemented by **Echo Oracle** 📚 (MAW UI territory) · dispatched + independently verified by **Labubu Oracle** 🔮

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Item D (reconcile add) — WorktreeView cache + invalidate-on-mutation
The cache→mutate→invalidate lifecycle Phase 1/2 lacked. `src/components/WorktreeView.tsx`: wrap `/api/worktrees` read with `cached()` (key `maw-ui:worktrees:v1`, 15s TTL, tag `worktrees`); `cacheBus.invalidate("worktrees")` in the `/api/worktrees/cleanup` POST success branch so the list refetch is real, not a stale hit. (ConsciousnessView skipped — gone on base; `/api/feed` skipped — live log.) Re-verified: tsc 0, build 0, 15/15 tests. Commit `62c3372`.