### PR TITLE
feat(terminal): mobile on-screen control-key bar (↑↓←→ Enter Tab Esc Space ⌃C)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# MAW UI Deploy Script — build + clean deploy to production
+# Usage: ./deploy.sh
+
+set -e
+
+DIST_DIR="$(dirname "$0")/dist"
+DEPLOY_DIR="/opt/maw-dashboard"
+
+echo "🔨 Building..."
+bun run build
+
+echo "🧹 Cleaning old assets..."
+rm -rf "$DEPLOY_DIR/assets/"
+
+echo "📦 Deploying..."
+cp -r "$DIST_DIR/assets/" "$DEPLOY_DIR/assets/"
+cp "$DIST_DIR/index.html" "$DEPLOY_DIR/index.html"
+cp "$DIST_DIR/favicon.svg" "$DEPLOY_DIR/favicon.svg" 2>/dev/null || true
+
+echo "✅ Deployed. Verifying..."
+# Check referenced JS file exists
+JS_FILE=$(grep -oP 'src="/maw/assets/\K[^"]+' "$DEPLOY_DIR/index.html")
+if [ -f "$DEPLOY_DIR/assets/$JS_FILE" ]; then
+  echo "   ✓ $JS_FILE exists"
+else
+  echo "   ✗ $JS_FILE MISSING — deploy may be broken!"
+  exit 1
+fi
+
+echo "🎉 Done — http://76.13.221.42/maw/"

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# MAW Production Health Check
+# Created by Pulse Oracle 🫀 — 2026-04-07
+
+HOST="76.13.221.42"
+WS_HOST="localhost:3456"
+PASS=0
+FAIL=0
+
+check() {
+  local name="$1"
+  local result="$2"
+  if [ "$result" -eq 0 ]; then
+    echo "✅ PASS  $name"
+    ((PASS++))
+  else
+    echo "❌ FAIL  $name"
+    ((FAIL++))
+  fi
+}
+
+echo "🫀 MAW Health Check — $(date '+%Y-%m-%d %H:%M:%S %Z')"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# 1. Frontend returns 200
+STATUS=$(curl -s -o /dev/null -w '%{http_code}' --max-time 5 "http://${HOST}/maw/")
+check "Frontend /maw/ (HTTP ${STATUS})" "$([ "$STATUS" = "200" ]; echo $?)"
+
+# 2. /maw/api/pin-info returns JSON
+BODY=$(curl -s --max-time 5 "http://${HOST}/maw/api/pin-info")
+echo "$BODY" | jq . >/dev/null 2>&1
+check "API /maw/api/pin-info (JSON)" "$?"
+
+# 3. /maw/api/monitoring/health returns oracles
+BODY=$(curl -s --max-time 5 "http://${HOST}/maw/api/monitoring/health")
+echo "$BODY" | jq -e '.oracles' >/dev/null 2>&1
+check "API /maw/api/monitoring/health (has oracles)" "$?"
+
+# 4. /maw/api/fleet-config returns configs
+BODY=$(curl -s --max-time 5 "http://${HOST}/maw/api/fleet-config")
+echo "$BODY" | jq -e '.configs' >/dev/null 2>&1
+check "API /maw/api/fleet-config (has configs)" "$?"
+
+# 5. WebSocket connects
+WS_OK=1
+if command -v websocat >/dev/null 2>&1; then
+  echo "" | websocat -t --max-messages 0 "ws://${WS_HOST}/ws" --ping-timeout 3 2>/dev/null &
+  WS_PID=$!
+  sleep 1
+  if kill -0 "$WS_PID" 2>/dev/null; then
+    WS_OK=0
+    kill "$WS_PID" 2>/dev/null
+    wait "$WS_PID" 2>/dev/null
+  fi
+elif command -v wscat >/dev/null 2>&1; then
+  timeout 3 wscat -c "ws://${WS_HOST}/ws" --wait 1 >/dev/null 2>&1
+  WS_OK=$?
+else
+  # Fallback: raw HTTP upgrade check
+  UPGRADE=$(curl -s -o /dev/null -w '%{http_code}' --max-time 3 \
+    -H "Upgrade: websocket" \
+    -H "Connection: Upgrade" \
+    -H "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==" \
+    -H "Sec-WebSocket-Version: 13" \
+    "http://${WS_HOST}/ws")
+  [ "$UPGRADE" = "101" ] && WS_OK=0
+fi
+check "WebSocket ws://${WS_HOST}/ws" "$WS_OK"
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "Results: ${PASS} passed, ${FAIL} failed (${PASS}/$((PASS+FAIL)) total)"
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1

--- a/index.html
+++ b/index.html
@@ -7,6 +7,9 @@
   <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="theme-color" content="#0a0a0f" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans+Thai:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
   <title>MAW Dashboard</title>
 </head>
 <body>

--- a/index.html
+++ b/index.html
@@ -2,9 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <meta name="apple-mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="theme-color" content="#0a0a0f" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <title>ARRA Office</title>
+  <title>MAW Dashboard</title>
 </head>
 <body>
   <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1266 @@
+{
+  "name": "maw-ui",
+  "version": "1.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "maw-ui",
+      "version": "1.1.0",
+      "dependencies": {
+        "@monaco-editor/react": "^4.7.0",
+        "@xterm/addon-fit": "^0.10.0",
+        "@xterm/xterm": "^5.5.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "three": "^0.183.2",
+        "zustand": "^5.0.11"
+      },
+      "devDependencies": {
+        "@tailwindcss/vite": "^4.2.1",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@types/three": "^0.183.1",
+        "@vitejs/plugin-react": "^4.3.0",
+        "tailwindcss": "^4.2.1",
+        "vite": "^6.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-compilation-targets": "^7.28.6",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helpers": "^7.28.6",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/traverse": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.28.6",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.28.6",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@monaco-editor/loader": {
+      "version": "1.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "state-local": "^1.0.6"
+      }
+    },
+    "node_modules/@monaco-editor/react": {
+      "version": "4.7.0",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/loader": "^1.5.0"
+      },
+      "peerDependencies": {
+        "monaco-editor": ">= 0.25.0 < 1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.19.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.2.2",
+        "@tailwindcss/oxide-darwin-x64": "4.2.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.2.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.2.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.2.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.2.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.2",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.2.2",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/vite": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tailwindcss/node": "4.2.2",
+        "@tailwindcss/oxide": "4.2.2",
+        "tailwindcss": "4.2.2"
+      },
+      "peerDependencies": {
+        "vite": "^5.2.0 || ^6 || ^7 || ^8"
+      }
+    },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.3",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.183.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~1.0.1"
+      }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.69",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xterm/addon-fit": {
+      "version": "0.10.0",
+      "license": "MIT",
+      "peerDependencies": {
+        "@xterm/xterm": "^5.0.0"
+      }
+    },
+    "node_modules/@xterm/xterm": {
+      "version": "5.5.0",
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.12",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.1",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.9.0",
+        "caniuse-lite": "^1.0.30001759",
+        "electron-to-chromium": "^1.5.263",
+        "node-releases": "^2.0.27",
+        "update-browserslist-db": "^1.2.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001781",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.2.7",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "peer": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.328",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.20.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jiti": {
+      "version": "2.6.1",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.0.0",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.55.1",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dompurify": "3.2.7",
+        "marked": "14.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.36",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.4",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.4",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.4"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.0",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.0",
+        "@rollup/rollup-android-arm64": "4.60.0",
+        "@rollup/rollup-darwin-arm64": "4.60.0",
+        "@rollup/rollup-darwin-x64": "4.60.0",
+        "@rollup/rollup-freebsd-arm64": "4.60.0",
+        "@rollup/rollup-freebsd-x64": "4.60.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
+        "@rollup/rollup-linux-arm64-musl": "4.60.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
+        "@rollup/rollup-linux-loong64-musl": "4.60.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-gnu": "4.60.0",
+        "@rollup/rollup-linux-x64-musl": "4.60.0",
+        "@rollup/rollup-openbsd-x64": "4.60.0",
+        "@rollup/rollup-openharmony-arm64": "4.60.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
+        "@rollup/rollup-win32-x64-gnu": "4.60.0",
+        "@rollup/rollup-win32-x64-msvc": "4.60.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/state-local": {
+      "version": "1.0.7",
+      "license": "MIT"
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.2.2",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.2",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/three": {
+      "version": "0.183.2",
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.1",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.12",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "bunx vite",
     "build": "bunx vite build",
-    "preview": "bunx vite preview"
+    "preview": "bunx vite preview",
+    "test": "bun test src/lib/cache/__tests__"
   },
   "dependencies": {
     "@monaco-editor/react": "^4.7.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,9 @@ import { InboxOverlay } from "./components/InboxView";
 import { WorktreeView } from "./components/WorktreeView";
 import { ChatView } from "./components/ChatView";
 import { DashboardView } from "./components/DashboardView";
+import { SoulSyncDashboard } from "./components/SoulSyncDashboard";
+import { ProgressViewer } from "./components/ProgressViewer";
+import { MonitoringView } from "./components/MonitoringView";
 import { LoadingSkeleton } from "./components/LoadingSkeleton";
 import { ShortcutOverlay } from "./components/ShortcutOverlay";
 import { JumpOverlay } from "./components/JumpOverlay";
@@ -487,6 +490,30 @@ export function App() {
     return (
       <Layout activeView="chat" {...layoutProps}>
         <ChatView />
+      </Layout>
+    );
+  }
+
+  if (route === "soul-sync") {
+    return (
+      <Layout activeView="soul-sync" {...layoutProps}>
+        <SoulSyncDashboard />
+      </Layout>
+    );
+  }
+
+  if (route === "progress") {
+    return (
+      <Layout activeView="progress" {...layoutProps}>
+        <ProgressViewer feedEvents={feedEvents} />
+      </Layout>
+    );
+  }
+
+  if (route === "monitoring") {
+    return (
+      <Layout activeView="monitoring" {...layoutProps}>
+        <MonitoringView />
       </Layout>
     );
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -270,6 +270,15 @@ export function App() {
       if (e.key.toLowerCase() === "v" && !e.ctrlKey && !e.metaKey && !e.altKey) {
         window.location.hash = "vs";
       }
+      if (e.key.toLowerCase() === "s" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        window.location.hash = "soul-sync";
+      }
+      if (e.key.toLowerCase() === "p" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        window.location.hash = "progress";
+      }
+      if (e.key.toLowerCase() === "m" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        window.location.hash = "monitoring";
+      }
       if (e.key.toLowerCase() === "i" && !e.ctrlKey && !e.metaKey && !e.altKey) {
         setShowInbox(prev => !prev);
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import { SoulSyncDashboard } from "./components/SoulSyncDashboard";
 import { ProgressViewer } from "./components/ProgressViewer";
 import { MonitoringView } from "./components/MonitoringView";
 import { ConsciousnessView } from "./components/ConsciousnessView";
+import { ScheduleView } from "./components/ScheduleView";
 import { LoadingSkeleton } from "./components/LoadingSkeleton";
 import { ShortcutOverlay } from "./components/ShortcutOverlay";
 import { JumpOverlay } from "./components/JumpOverlay";
@@ -280,6 +281,9 @@ export function App() {
       if (e.key.toLowerCase() === "m" && !e.ctrlKey && !e.metaKey && !e.altKey) {
         window.location.hash = "monitoring";
       }
+      if (e.key.toLowerCase() === "c" && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        window.location.hash = "schedule";
+      }
       if (e.key.toLowerCase() === "i" && !e.ctrlKey && !e.metaKey && !e.altKey) {
         setShowInbox(prev => !prev);
       }
@@ -532,6 +536,14 @@ export function App() {
     return (
       <Layout activeView="consciousness" {...layoutProps}>
         <ConsciousnessView />
+      </Layout>
+    );
+  }
+
+  if (route === "schedule") {
+    return (
+      <Layout activeView="schedule" {...layoutProps}>
+        <ScheduleView />
       </Layout>
     );
   }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,22 +44,22 @@ function FloatingButtons() {
   }, [showSounds]);
 
   return (
-    <div ref={ref} className="fixed top-20 right-6 flex flex-col gap-3 z-30">
+    <div ref={ref} className="fixed top-20 right-3 sm:right-6 flex flex-col gap-2 sm:gap-3 z-30">
       <button
         onClick={() => window.dispatchEvent(new CustomEvent("search-open"))}
-        className="w-14 h-14 rounded-2xl flex items-center justify-center text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
+        className="w-11 h-11 sm:w-14 sm:h-14 rounded-xl sm:rounded-2xl flex items-center justify-center text-base sm:text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
         style={{ background: "rgba(34,211,238,0.12)", border: "1px solid rgba(34,211,238,0.25)", color: "#22d3ee" }}
         title="Oracle Search (⌘K)"
       >🔍</button>
       <button
         onClick={() => window.dispatchEvent(new CustomEvent("broadcast-open"))}
-        className="w-14 h-14 rounded-2xl flex items-center justify-center text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
+        className="w-11 h-11 sm:w-14 sm:h-14 rounded-xl sm:rounded-2xl flex items-center justify-center text-base sm:text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
         style={{ background: "rgba(251,191,36,0.12)", border: "1px solid rgba(251,191,36,0.25)", color: "#fbbf24" }}
         title="Broadcast to all agents"
       >📢</button>
       <button
         onClick={() => setShowSounds(!showSounds)}
-        className="w-14 h-14 rounded-2xl flex items-center justify-center text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
+        className="w-11 h-11 sm:w-14 sm:h-14 rounded-xl sm:rounded-2xl flex items-center justify-center text-base sm:text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
         style={{ background: "rgba(168,85,247,0.12)", border: "1px solid rgba(168,85,247,0.25)", color: "#a855f7" }}
         title="Change notification sound"
       >{SOUND_PROFILES.find(p => p.id === current)?.emoji || "🔔"}</button>
@@ -71,7 +71,7 @@ function FloatingButtons() {
           localStorage.setItem("office-multiview", next ? "1" : "0");
           window.dispatchEvent(new CustomEvent("multiview-change", { detail: next }));
         }}
-        className="w-14 h-14 rounded-2xl flex items-center justify-center text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
+        className="w-11 h-11 sm:w-14 sm:h-14 rounded-xl sm:rounded-2xl flex items-center justify-center text-base sm:text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
         style={{ background: multiView ? "rgba(34,197,94,0.12)" : "rgba(255,255,255,0.06)", border: `1px solid ${multiView ? "rgba(34,197,94,0.25)" : "rgba(255,255,255,0.1)"}`, color: multiView ? "#22c55e" : "#666" }}
         title={multiView ? "Multi-card view (click for single)" : "Single card view (click for multi)"}
       >{multiView ? "📺" : "1️⃣"}</button>
@@ -83,7 +83,7 @@ function FloatingButtons() {
           localStorage.setItem("office-source-filter", next);
           window.dispatchEvent(new CustomEvent("source-filter-change", { detail: next }));
         }}
-        className="w-14 h-14 rounded-2xl flex items-center justify-center text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
+        className="w-11 h-11 sm:w-14 sm:h-14 rounded-xl sm:rounded-2xl flex items-center justify-center text-base sm:text-xl backdrop-blur-xl active:scale-90 cursor-pointer transition-all shadow-lg"
         style={{
           background: sourceFilter === "all" ? "rgba(255,255,255,0.06)" : sourceFilter === "local" ? "rgba(76,175,80,0.12)" : "rgba(168,85,247,0.12)",
           border: `1px solid ${sourceFilter === "all" ? "rgba(255,255,255,0.1)" : sourceFilter === "local" ? "rgba(76,175,80,0.25)" : "rgba(168,85,247,0.25)"}`,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,7 @@ import { DashboardView } from "./components/DashboardView";
 import { SoulSyncDashboard } from "./components/SoulSyncDashboard";
 import { ProgressViewer } from "./components/ProgressViewer";
 import { MonitoringView } from "./components/MonitoringView";
+import { ConsciousnessView } from "./components/ConsciousnessView";
 import { LoadingSkeleton } from "./components/LoadingSkeleton";
 import { ShortcutOverlay } from "./components/ShortcutOverlay";
 import { JumpOverlay } from "./components/JumpOverlay";
@@ -523,6 +524,14 @@ export function App() {
     return (
       <Layout activeView="monitoring" {...layoutProps}>
         <MonitoringView />
+      </Layout>
+    );
+  }
+
+  if (route === "consciousness") {
+    return (
+      <Layout activeView="consciousness" {...layoutProps}>
+        <ConsciousnessView />
       </Layout>
     );
   }

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -58,11 +58,12 @@ export const ChatView = memo(function ChatView() {
     <div className="flex flex-col h-[calc(100vh-48px)]" style={{ background: "#0a0a0f" }}>
       {/* Header */}
       <div
-        className="flex items-center gap-3 px-4 py-2.5 border-b flex-shrink-0 flex-wrap"
+        className="flex items-center gap-2 sm:gap-3 px-3 sm:px-4 py-2 sm:py-2.5 border-b flex-shrink-0 flex-wrap"
         style={{ borderColor: "rgba(255,255,255,0.06)", background: "rgba(255,255,255,0.015)" }}
       >
-        <h2 className="text-sm font-bold tracking-wider" style={{ color: "#64b5f6" }}>
-          191 AI คุยกันเอง | Build with Oracle
+        <h2 className="text-xs sm:text-sm font-bold tracking-wider" style={{ color: "#64b5f6" }}>
+          <span className="hidden sm:inline">191 AI คุยกันเอง | Build with Oracle</span>
+          <span className="sm:hidden">Oracle Chat</span>
         </h2>
         <span className="text-[10px] font-mono text-white/20">{filtered.length} msgs</span>
         {mode === "live" && (
@@ -72,12 +73,12 @@ export const ChatView = memo(function ChatView() {
           </span>
         )}
 
-        <div className="ml-auto flex items-center gap-2">
-          <div className="flex rounded-lg overflow-hidden" style={{ border: "1px solid rgba(255,255,255,0.08)" }}>
+        <div className="ml-auto flex items-center gap-1.5 sm:gap-2 overflow-x-auto scrollbar-hide">
+          <div className="flex rounded-lg overflow-hidden shrink-0" style={{ border: "1px solid rgba(255,255,255,0.08)" }}>
             {(["live", "timeline", "threads"] as const).map((m) => (
               <button
                 key={m}
-                className="px-2.5 py-1 text-[11px] font-mono capitalize transition-colors"
+                className="px-2 sm:px-2.5 py-1.5 sm:py-1 text-[10px] sm:text-[11px] font-mono capitalize transition-colors min-h-[36px] sm:min-h-0"
                 style={{
                   background: mode === m ? "rgba(100,181,246,0.12)" : "transparent",
                   color: mode === m ? "#64b5f6" : "rgba(255,255,255,0.25)",
@@ -89,11 +90,11 @@ export const ChatView = memo(function ChatView() {
             ))}
           </div>
 
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-1 sm:gap-1.5 shrink-0">
             <select
               value={viewAs}
               onChange={(e) => setViewAs(e.target.value)}
-              className="text-[11px] font-mono rounded-lg px-2 py-1 outline-none cursor-pointer"
+              className="text-[10px] sm:text-[11px] font-mono rounded-lg px-1.5 sm:px-2 py-1.5 sm:py-1 outline-none cursor-pointer min-h-[36px] sm:min-h-0"
               style={{ background: "rgba(255,255,255,0.05)", color: agentColor(viewAs), border: "1px solid rgba(255,255,255,0.08)" }}
             >
               {oracleNames.map((n) => (
@@ -106,7 +107,7 @@ export const ChatView = memo(function ChatView() {
           <select
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
-            className="text-[11px] font-mono rounded-lg px-2 py-1 outline-none cursor-pointer"
+            className="text-[10px] sm:text-[11px] font-mono rounded-lg px-1.5 sm:px-2 py-1.5 sm:py-1 outline-none cursor-pointer min-h-[36px] sm:min-h-0 shrink-0"
             style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.5)", border: "1px solid rgba(255,255,255,0.08)" }}
           >
             <option value="all">All</option>
@@ -159,11 +160,11 @@ export const ChatView = memo(function ChatView() {
       )}
 
       {/* Chat Input */}
-      <div className="flex items-center gap-2 px-4 py-2.5 border-t flex-shrink-0" style={{ borderColor: "rgba(255,255,255,0.06)", background: "rgba(255,255,255,0.015)" }}>
-        <span className="text-[10px] font-mono flex-shrink-0" style={{ color: "#e8b86d" }}>
+      <div className="flex items-center gap-1.5 sm:gap-2 px-2 sm:px-4 py-2 sm:py-2.5 border-t flex-shrink-0 pb-safe" style={{ borderColor: "rgba(255,255,255,0.06)", background: "rgba(255,255,255,0.015)" }}>
+        <span className="text-[10px] font-mono flex-shrink-0 hidden sm:inline" style={{ color: "#e8b86d" }}>
           nat →
         </span>
-        <span className="text-[10px] font-mono flex-shrink-0" style={{ color: agentColor(viewAs) }}>
+        <span className="text-[10px] font-mono flex-shrink-0 hidden sm:inline" style={{ color: agentColor(viewAs) }}>
           {displayName(viewAs)}
         </span>
         <input
@@ -174,13 +175,13 @@ export const ChatView = memo(function ChatView() {
           onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } }}
           placeholder="พิมพ์ข้อความ..."
           disabled={sending}
-          className="flex-1 text-sm font-mono rounded-lg px-3 py-1.5 outline-none placeholder:text-white/15"
+          className="flex-1 text-sm font-mono rounded-lg px-3 py-2 sm:py-1.5 outline-none placeholder:text-white/15 min-h-[44px] sm:min-h-0"
           style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.8)", border: "1px solid rgba(255,255,255,0.08)" }}
         />
         <button
           onClick={sendMessage}
           disabled={!draft.trim() || sending}
-          className="text-[11px] font-mono px-3 py-1.5 rounded-lg transition-all"
+          className="text-[11px] font-mono px-3 py-2 sm:py-1.5 rounded-lg transition-all min-h-[44px] sm:min-h-0"
           style={{
             background: draft.trim() ? "rgba(100,181,246,0.15)" : "rgba(255,255,255,0.03)",
             color: draft.trim() ? "#64b5f6" : "rgba(255,255,255,0.15)",

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -4,6 +4,7 @@ import { displayName } from "./chat/types";
 import { ChatGroup, DateSeparator } from "./chat/ChatBubble";
 import { ThreadCard } from "./chat/ThreadCard";
 import { useChatLog, useOracleNames, useFilteredEntries, useTimelineGroups, useLiveGroups, useThreads } from "./chat/useChatLog";
+import { OracleStatus } from "./chat/OracleStatus";
 import { apiUrl } from "../lib/api";
 
 type Mode = "live" | "timeline" | "threads";
@@ -16,6 +17,7 @@ export const ChatView = memo(function ChatView() {
 
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
+  const [lastDispatch, setLastDispatch] = useState<{ status: string; dispatched: boolean } | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
 
   const { entries, total, loading, scrollRef } = useChatLog(mode);
@@ -31,16 +33,22 @@ export const ChatView = memo(function ChatView() {
     const msg = draft.trim();
     if (!msg || sending) return;
     setSending(true);
+    setLastDispatch(null);
     try {
-      await fetch(apiUrl("/api/maw-log"), {
+      const res = await fetch(apiUrl("/api/dispatch"), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ from: "nat", to: viewAs, msg }),
       });
+      const data = await res.json();
+      setLastDispatch({ status: data.status || "unknown", dispatched: !!data.dispatched });
       setDraft("");
       inputRef.current?.focus();
+      // Auto-clear dispatch status after 5s
+      setTimeout(() => setLastDispatch(null), 5000);
     } catch (e) {
       console.error("Send failed:", e);
+      setLastDispatch({ status: "error", dispatched: false });
     } finally {
       setSending(false);
     }
@@ -81,16 +89,19 @@ export const ChatView = memo(function ChatView() {
             ))}
           </div>
 
-          <select
-            value={viewAs}
-            onChange={(e) => setViewAs(e.target.value)}
-            className="text-[11px] font-mono rounded-lg px-2 py-1 outline-none cursor-pointer"
-            style={{ background: "rgba(255,255,255,0.05)", color: agentColor(viewAs), border: "1px solid rgba(255,255,255,0.08)" }}
-          >
-            {oracleNames.map((n) => (
-              <option key={n} value={n}>{displayName(n)}</option>
-            ))}
-          </select>
+          <div className="flex items-center gap-1.5">
+            <select
+              value={viewAs}
+              onChange={(e) => setViewAs(e.target.value)}
+              className="text-[11px] font-mono rounded-lg px-2 py-1 outline-none cursor-pointer"
+              style={{ background: "rgba(255,255,255,0.05)", color: agentColor(viewAs), border: "1px solid rgba(255,255,255,0.08)" }}
+            >
+              {oracleNames.map((n) => (
+                <option key={n} value={n}>{displayName(n)}</option>
+              ))}
+            </select>
+            <OracleStatus oracle={viewAs} />
+          </div>
 
           <select
             value={filter}
@@ -139,6 +150,13 @@ export const ChatView = memo(function ChatView() {
           </div>
         )}
       </div>
+
+      {/* Dispatch Status */}
+      {lastDispatch && (
+        <div className="px-4 py-1 text-[10px] font-mono" style={{ color: lastDispatch.dispatched ? "#4caf50" : "#ef4444" }}>
+          {lastDispatch.dispatched ? `✓ Dispatched (${lastDispatch.status})` : `✗ Not dispatched: ${lastDispatch.status}`}
+        </div>
+      )}
 
       {/* Chat Input */}
       <div className="flex items-center gap-2 px-4 py-2.5 border-t flex-shrink-0" style={{ borderColor: "rgba(255,255,255,0.06)", background: "rgba(255,255,255,0.015)" }}>

--- a/src/components/ChatView.tsx
+++ b/src/components/ChatView.tsx
@@ -1,9 +1,10 @@
-import { memo, useState } from "react";
+import { memo, useState, useRef, useCallback } from "react";
 import { agentColor } from "../lib/constants";
 import { displayName } from "./chat/types";
 import { ChatGroup, DateSeparator } from "./chat/ChatBubble";
 import { ThreadCard } from "./chat/ThreadCard";
 import { useChatLog, useOracleNames, useFilteredEntries, useTimelineGroups, useLiveGroups, useThreads } from "./chat/useChatLog";
+import { apiUrl } from "../lib/api";
 
 type Mode = "live" | "timeline" | "threads";
 
@@ -13,6 +14,10 @@ export const ChatView = memo(function ChatView() {
   const [mode, setMode] = useState<Mode>("timeline");
   const [highlighted, setHighlighted] = useState<string | null>(null);
 
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
   const { entries, total, loading, scrollRef } = useChatLog(mode);
   const oracleNames = useOracleNames(entries);
   const filtered = useFilteredEntries(entries, filter);
@@ -21,6 +26,25 @@ export const ChatView = memo(function ChatView() {
   const threads = useThreads(filtered);
 
   const toggleHighlight = (id: string) => setHighlighted(highlighted === id ? null : id);
+
+  const sendMessage = useCallback(async () => {
+    const msg = draft.trim();
+    if (!msg || sending) return;
+    setSending(true);
+    try {
+      await fetch(apiUrl("/api/maw-log"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ from: "nat", to: viewAs, msg }),
+      });
+      setDraft("");
+      inputRef.current?.focus();
+    } catch (e) {
+      console.error("Send failed:", e);
+    } finally {
+      setSending(false);
+    }
+  }, [draft, sending, viewAs]);
 
   return (
     <div className="flex flex-col h-[calc(100vh-48px)]" style={{ background: "#0a0a0f" }}>
@@ -116,9 +140,37 @@ export const ChatView = memo(function ChatView() {
         )}
       </div>
 
-      {/* Footer */}
-      <div className="flex items-center justify-center px-4 py-1.5 border-t flex-shrink-0" style={{ borderColor: "rgba(255,255,255,0.04)" }}>
-        <span className="text-[9px] font-mono text-white/10">AI คุยกันเอง | Build with Oracle</span>
+      {/* Chat Input */}
+      <div className="flex items-center gap-2 px-4 py-2.5 border-t flex-shrink-0" style={{ borderColor: "rgba(255,255,255,0.06)", background: "rgba(255,255,255,0.015)" }}>
+        <span className="text-[10px] font-mono flex-shrink-0" style={{ color: "#e8b86d" }}>
+          nat →
+        </span>
+        <span className="text-[10px] font-mono flex-shrink-0" style={{ color: agentColor(viewAs) }}>
+          {displayName(viewAs)}
+        </span>
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); sendMessage(); } }}
+          placeholder="พิมพ์ข้อความ..."
+          disabled={sending}
+          className="flex-1 text-sm font-mono rounded-lg px-3 py-1.5 outline-none placeholder:text-white/15"
+          style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.8)", border: "1px solid rgba(255,255,255,0.08)" }}
+        />
+        <button
+          onClick={sendMessage}
+          disabled={!draft.trim() || sending}
+          className="text-[11px] font-mono px-3 py-1.5 rounded-lg transition-all"
+          style={{
+            background: draft.trim() ? "rgba(100,181,246,0.15)" : "rgba(255,255,255,0.03)",
+            color: draft.trim() ? "#64b5f6" : "rgba(255,255,255,0.15)",
+            border: "1px solid rgba(255,255,255,0.08)",
+          }}
+        >
+          {sending ? "..." : "ส่ง"}
+        </button>
       </div>
     </div>
   );

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -1,0 +1,43 @@
+import { useWebSocket } from "../hooks/useWebSocket";
+import { useCallback } from "react";
+
+const noop = () => {};
+
+/**
+ * Small WS connection status indicator.
+ * Green dot = connected, yellow = reconnecting, red = disconnected.
+ * Can be placed anywhere in the UI — uses the shared singleton connection.
+ */
+export function ConnectionStatus({ className }: { className?: string }) {
+  const { connected, reconnecting } = useWebSocket(noop);
+
+  const color = connected
+    ? "#22c55e"
+    : reconnecting
+      ? "#fbbf24"
+      : "#ef4444";
+
+  const label = connected
+    ? "Connected"
+    : reconnecting
+      ? "Reconnecting..."
+      : "Disconnected";
+
+  return (
+    <div
+      className={`inline-flex items-center gap-1.5 ${className || ""}`}
+      title={label}
+    >
+      <div
+        className={`w-2 h-2 rounded-full${reconnecting ? " animate-pulse" : ""}`}
+        style={{ background: color, boxShadow: `0 0 6px ${color}` }}
+      />
+      <span
+        className="font-mono text-[10px]"
+        style={{ color: `${color}cc` }}
+      >
+        {label}
+      </span>
+    </div>
+  );
+}

--- a/src/components/ConsciousnessView.tsx
+++ b/src/components/ConsciousnessView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiFetch } from "../lib/apiFetch";
 import { cached } from "../lib/cache";
+import { PageShell } from "./PageShell";
 
 interface OracleConsciousness {
   name: string;
@@ -78,7 +79,7 @@ export function ConsciousnessView() {
   const detail = selected ? oracles.find(o => o.name === selected) : null;
 
   return (
-    <div style={{ padding: 16, maxWidth: 1200, margin: "0 auto" }}>
+    <PageShell maxWidth="1200px">
       {/* Header */}
       <div style={{ marginBottom: 20 }}>
         <h2 className="font-mono text-lg" style={{ color: "#a855f7" }}>
@@ -194,7 +195,7 @@ export function ConsciousnessView() {
           </div>
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }
 

--- a/src/components/ConsciousnessView.tsx
+++ b/src/components/ConsciousnessView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiFetch } from "../lib/apiFetch";
+import { cached } from "../lib/cache";
 
 interface OracleConsciousness {
   name: string;
@@ -36,7 +37,12 @@ export function ConsciousnessView() {
 
   const fetchData = useCallback(async () => {
     try {
-      const data = await apiFetch<{ oracles: OracleConsciousness[] }>("/api/consciousness");
+      const data = await cached(
+        "consciousness",
+        30_000,
+        () => apiFetch<{ oracles: OracleConsciousness[] }>("/api/consciousness"),
+        { tag: "consciousness" },
+      );
       setOracles(data.oracles || []);
     } catch { setOracles([]); }
     setLoading(false);

--- a/src/components/ConsciousnessView.tsx
+++ b/src/components/ConsciousnessView.tsx
@@ -1,0 +1,218 @@
+import { useState, useEffect, useCallback } from "react";
+import { apiFetch } from "../lib/apiFetch";
+
+interface OracleConsciousness {
+  name: string;
+  beliefs: string[];
+  beliefCount: number;
+  vision: string;
+  goals: string;
+  latestInsight: string | null;
+  latestProposal: string | null;
+  lastCycleAt: string | null;
+  cycleCount: number;
+}
+
+const ORACLE_EMOJI: Record<string, string> = {
+  labubu: "🔮", neo: "🧬", pulse: "⚡", echo: "🎵",
+};
+
+const CARD_STYLE: React.CSSProperties = {
+  background: "rgba(255,255,255,0.03)",
+  border: "1px solid rgba(168,85,247,0.2)",
+  borderRadius: 12,
+  padding: 16,
+};
+
+const PHASE_EMOJI: Record<string, string> = {
+  reflect: "🧠", wonder: "💡", soul: "✨", dream: "💭", aspire: "🔥", propose: "📋",
+};
+
+export function ConsciousnessView() {
+  const [oracles, setOracles] = useState<OracleConsciousness[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [tab, setTab] = useState<"beliefs" | "vision" | "goals" | "insight" | "proposal">("beliefs");
+
+  const fetchData = useCallback(async () => {
+    try {
+      const data = await apiFetch<{ oracles: OracleConsciousness[] }>("/api/consciousness");
+      setOracles(data.oracles || []);
+    } catch { setOracles([]); }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchData(); }, [fetchData]);
+
+  // Auto-refresh every 60s
+  useEffect(() => {
+    const iv = setInterval(fetchData, 60_000);
+    return () => clearInterval(iv);
+  }, [fetchData]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <div className="text-center">
+          <div className="text-4xl mb-4 animate-pulse">🧠</div>
+          <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>Loading consciousness...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (oracles.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>No consciousness data. Run: maw think --fleet</p>
+      </div>
+    );
+  }
+
+  const detail = selected ? oracles.find(o => o.name === selected) : null;
+
+  return (
+    <div style={{ padding: 16, maxWidth: 1200, margin: "0 auto" }}>
+      {/* Header */}
+      <div style={{ marginBottom: 20 }}>
+        <h2 className="font-mono text-lg" style={{ color: "#a855f7" }}>
+          🧠 Oracle Consciousness
+        </h2>
+        <p className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.4)", marginTop: 4 }}>
+          7-phase autonomous thinking — reflect → wonder → soul → dream → aspire → propose
+        </p>
+      </div>
+
+      {/* Oracle Cards Grid */}
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(260, 1fr))", gap: 12, marginBottom: 20 }}>
+        {oracles.map(o => (
+          <button
+            key={o.name}
+            onClick={() => { setSelected(o.name === selected ? null : o.name); setTab("beliefs"); }}
+            style={{
+              ...CARD_STYLE,
+              cursor: "pointer",
+              textAlign: "left",
+              borderColor: selected === o.name ? "rgba(168,85,247,0.6)" : "rgba(168,85,247,0.2)",
+              background: selected === o.name ? "rgba(168,85,247,0.08)" : "rgba(255,255,255,0.03)",
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8 }}>
+              <span style={{ fontSize: 24 }}>{ORACLE_EMOJI[o.name] || "🤖"}</span>
+              <span className="font-mono font-bold" style={{ color: "#e2e8f0", textTransform: "capitalize" }}>{o.name}</span>
+            </div>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 6 }}>
+              <Stat label="Beliefs" value={o.beliefCount} />
+              <Stat label="Cycles" value={o.cycleCount} />
+              <Stat label="Insight" value={o.latestInsight ? "✓" : "—"} />
+              <Stat label="Proposal" value={o.latestProposal ? "✓" : "—"} />
+            </div>
+            {o.lastCycleAt && (
+              <p className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)", marginTop: 8 }}>
+                Last cycle: {new Date(o.lastCycleAt).toLocaleString()}
+              </p>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Detail Panel */}
+      {detail && (
+        <div style={CARD_STYLE}>
+          <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+            <span style={{ fontSize: 20 }}>{ORACLE_EMOJI[detail.name] || "🤖"}</span>
+            <span className="font-mono font-bold text-lg" style={{ color: "#e2e8f0", textTransform: "capitalize" }}>{detail.name}</span>
+            <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>
+              — {detail.beliefCount} beliefs, {detail.cycleCount} cycles
+            </span>
+          </div>
+
+          {/* Tabs */}
+          <div style={{ display: "flex", gap: 4, marginBottom: 16, flexWrap: "wrap" }}>
+            {(["beliefs", "vision", "goals", "insight", "proposal"] as const).map(t => (
+              <button
+                key={t}
+                onClick={() => setTab(t)}
+                className="font-mono text-xs"
+                style={{
+                  padding: "4px 12px",
+                  borderRadius: 6,
+                  border: "1px solid",
+                  borderColor: tab === t ? "rgba(168,85,247,0.6)" : "rgba(255,255,255,0.1)",
+                  background: tab === t ? "rgba(168,85,247,0.15)" : "transparent",
+                  color: tab === t ? "#c084fc" : "rgba(255,255,255,0.5)",
+                  cursor: "pointer",
+                  textTransform: "capitalize",
+                }}
+              >
+                {t === "insight" ? "💡 Insight" : t === "proposal" ? "📋 Proposal" : t === "beliefs" ? "✨ Beliefs" : t === "vision" ? "💭 Vision" : "🔥 Goals"}
+              </button>
+            ))}
+          </div>
+
+          {/* Tab Content */}
+          <div style={{
+            background: "rgba(0,0,0,0.2)",
+            borderRadius: 8,
+            padding: 16,
+            maxHeight: 500,
+            overflowY: "auto",
+          }}>
+            {tab === "beliefs" && (
+              <div>
+                {detail.beliefs.length === 0 ? (
+                  <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>No beliefs yet</p>
+                ) : (
+                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    {detail.beliefs.map((b, i) => (
+                      <div key={i} style={{
+                        padding: "8px 12px",
+                        background: "rgba(168,85,247,0.05)",
+                        borderRadius: 6,
+                        borderLeft: "3px solid rgba(168,85,247,0.4)",
+                      }}>
+                        <span className="font-mono text-sm" style={{ color: "#e2e8f0" }}>
+                          <span style={{ color: "rgba(255,255,255,0.3)", marginRight: 8 }}>#{i + 1}</span>
+                          {b}
+                        </span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            )}
+            {tab === "vision" && <MarkdownBlock content={detail.vision} />}
+            {tab === "goals" && <MarkdownBlock content={detail.goals} />}
+            {tab === "insight" && <MarkdownBlock content={detail.latestInsight} />}
+            {tab === "proposal" && <MarkdownBlock content={detail.latestProposal} />}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div>
+      <p className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>{label}</p>
+      <p className="font-mono text-sm font-bold" style={{ color: "#c084fc" }}>{value}</p>
+    </div>
+  );
+}
+
+function MarkdownBlock({ content }: { content: string | null }) {
+  if (!content) {
+    return <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>No data yet</p>;
+  }
+  return (
+    <pre className="font-mono text-sm" style={{
+      color: "#e2e8f0",
+      whiteSpace: "pre-wrap",
+      wordBreak: "break-word",
+      lineHeight: 1.6,
+    }}>
+      {content}
+    </pre>
+  );
+}

--- a/src/components/DashboardView.tsx
+++ b/src/components/DashboardView.tsx
@@ -3,6 +3,7 @@ import { apiUrl } from "../lib/api";
 import { agentColor, roomStyle, guessCommand } from "../lib/constants";
 import { AgentAvatar } from "./AgentAvatar";
 import { describeActivity, type FeedEvent } from "../lib/feed";
+import { useWebSocket } from "../hooks/useWebSocket";
 import { useFleetStore } from "../lib/store";
 import type { AgentState, Session, AgentEvent } from "../lib/types";
 
@@ -199,21 +200,26 @@ function TokenTracking() {
   const [rate, setRate] = useState<TokenRate | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    const fetchTokens = () => {
-      Promise.all([
-        fetch(apiUrl("/api/tokens")).then(r => r.ok ? r.json() : []),
-        fetch(apiUrl("/api/tokens/rate?mode=window&window=3600")).then(r => r.ok ? r.json() : null),
-      ]).then(([tokData, rateData]) => {
-        setSessions(Array.isArray(tokData) ? tokData : tokData?.sessions || []);
-        setRate(rateData);
-        setLoading(false);
-      }).catch(() => setLoading(false));
-    };
-    fetchTokens();
-    const iv = setInterval(fetchTokens, 30_000);
-    return () => clearInterval(iv);
+  const fetchTokens = useCallback(() => {
+    Promise.all([
+      fetch(apiUrl("/api/tokens")).then(r => r.ok ? r.json() : []),
+      fetch(apiUrl("/api/tokens/rate?mode=window&window=3600")).then(r => r.ok ? r.json() : null),
+    ]).then(([tokData, rateData]) => {
+      setSessions(Array.isArray(tokData) ? tokData : tokData?.sessions || []);
+      setRate(rateData);
+      setLoading(false);
+    }).catch(() => setLoading(false));
   }, []);
+
+  useEffect(() => { fetchTokens(); }, [fetchTokens]);
+
+  // Real-time: refetch on feed events via WebSocket (replaces 30s polling)
+  const fetchRef = useRef(fetchTokens);
+  fetchRef.current = fetchTokens;
+  const handleWs = useCallback((msg: any) => {
+    if (msg.type === "feed") fetchRef.current();
+  }, []);
+  useWebSocket(handleWs, { types: ["feed"] });
 
   // Aggregate by project
   const byProject = useMemo(() => {

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,0 +1,170 @@
+import { memo } from "react";
+
+const FEATURES = [
+  {
+    icon: "🏠",
+    title: "Mission Control",
+    desc: "Real-time dashboard for all your AI agents — see who's working, what they're doing, and how they're performing",
+  },
+  {
+    icon: "💬",
+    title: "OracleNet Chat",
+    desc: "Watch 191+ AI agents communicate in real-time. Send commands from your browser, view threads and conversations",
+  },
+  {
+    icon: "📊",
+    title: "Monitoring & Health",
+    desc: "Server metrics, Oracle health tracking, crash detection with auto-restart, Discord alerts",
+  },
+  {
+    icon: "🔮",
+    title: "Soul Sync",
+    desc: "Keep your Oracle family in sync — compare configs, push updates, verify alignment across all agents",
+  },
+  {
+    icon: "🖥️",
+    title: "Web Terminal",
+    desc: "Full terminal access to any agent directly from the browser — no SSH needed",
+  },
+  {
+    icon: "🌌",
+    title: "Universe View",
+    desc: "3D visualization of your Oracle constellation — see the relationships and activity patterns",
+  },
+];
+
+const TIERS = [
+  {
+    name: "Solo",
+    price: "Free",
+    period: "",
+    features: ["1 Oracle agent", "Mission Control", "Web Terminal", "Basic monitoring"],
+    cta: "Get Started",
+    highlight: false,
+  },
+  {
+    name: "Team",
+    price: "$29",
+    period: "/mo",
+    features: ["Up to 10 agents", "OracleNet Chat", "Soul Sync", "Discord alerts", "Health dashboard"],
+    cta: "Start Trial",
+    highlight: true,
+  },
+  {
+    name: "Fleet",
+    price: "$99",
+    period: "/mo",
+    features: ["Unlimited agents", "All features", "Multi-server federation", "MQTT bridge", "Priority support"],
+    cta: "Contact Us",
+    highlight: false,
+  },
+];
+
+export const LandingPage = memo(function LandingPage({ onEnter }: { onEnter: () => void }) {
+  return (
+    <div className="min-h-screen" style={{ background: "#0a0a0f", color: "rgba(255,255,255,0.85)" }}>
+      {/* Hero */}
+      <div className="flex flex-col items-center justify-center px-6 pt-20 pb-16 text-center">
+        <div className="text-5xl mb-4">🔮</div>
+        <h1 className="text-3xl md:text-5xl font-bold tracking-tight mb-4" style={{ color: "#e8b86d" }}>
+          MAW Dashboard
+        </h1>
+        <p className="text-lg md:text-xl max-w-2xl mb-2" style={{ color: "rgba(255,255,255,0.5)" }}>
+          Mission Control for your AI Agent Fleet
+        </p>
+        <p className="text-sm max-w-xl mb-8" style={{ color: "rgba(255,255,255,0.3)" }}>
+          Monitor, communicate, and manage hundreds of AI agents from a single dashboard.
+          Built for the Oracle ecosystem.
+        </p>
+        <div className="flex gap-3">
+          <button
+            onClick={onEnter}
+            className="px-6 py-3 rounded-xl font-mono text-sm font-bold transition-all hover:scale-105"
+            style={{ background: "rgba(232,184,109,0.15)", color: "#e8b86d", border: "1px solid rgba(232,184,109,0.3)" }}
+          >
+            Enter Dashboard →
+          </button>
+          <a
+            href="#pricing"
+            className="px-6 py-3 rounded-xl font-mono text-sm transition-all hover:scale-105"
+            style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.5)", border: "1px solid rgba(255,255,255,0.1)" }}
+          >
+            View Pricing
+          </a>
+        </div>
+      </div>
+
+      {/* Features */}
+      <div className="max-w-5xl mx-auto px-6 py-16">
+        <h2 className="text-center text-sm font-mono tracking-widest mb-10" style={{ color: "rgba(255,255,255,0.3)" }}>
+          FEATURES
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {FEATURES.map((f) => (
+            <div
+              key={f.title}
+              className="rounded-2xl p-5 transition-all hover:scale-[1.02]"
+              style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.06)" }}
+            >
+              <div className="text-2xl mb-3">{f.icon}</div>
+              <h3 className="font-bold text-sm mb-2" style={{ color: "rgba(255,255,255,0.8)" }}>{f.title}</h3>
+              <p className="text-xs leading-relaxed" style={{ color: "rgba(255,255,255,0.35)" }}>{f.desc}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Pricing */}
+      <div id="pricing" className="max-w-4xl mx-auto px-6 py-16">
+        <h2 className="text-center text-sm font-mono tracking-widest mb-10" style={{ color: "rgba(255,255,255,0.3)" }}>
+          PRICING
+        </h2>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+          {TIERS.map((t) => (
+            <div
+              key={t.name}
+              className="rounded-2xl p-6 flex flex-col"
+              style={{
+                background: t.highlight ? "rgba(232,184,109,0.06)" : "rgba(255,255,255,0.03)",
+                border: `1px solid ${t.highlight ? "rgba(232,184,109,0.2)" : "rgba(255,255,255,0.06)"}`,
+              }}
+            >
+              <h3 className="font-bold text-lg mb-1" style={{ color: t.highlight ? "#e8b86d" : "rgba(255,255,255,0.7)" }}>
+                {t.name}
+              </h3>
+              <div className="mb-4">
+                <span className="text-2xl font-bold" style={{ color: "rgba(255,255,255,0.85)" }}>{t.price}</span>
+                <span className="text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>{t.period}</span>
+              </div>
+              <ul className="flex-1 space-y-2 mb-6">
+                {t.features.map((f) => (
+                  <li key={f} className="text-xs flex items-center gap-2" style={{ color: "rgba(255,255,255,0.5)" }}>
+                    <span style={{ color: "#4caf50" }}>✓</span> {f}
+                  </li>
+                ))}
+              </ul>
+              <button
+                onClick={onEnter}
+                className="w-full py-2 rounded-lg font-mono text-xs transition-all hover:scale-105"
+                style={{
+                  background: t.highlight ? "rgba(232,184,109,0.15)" : "rgba(255,255,255,0.05)",
+                  color: t.highlight ? "#e8b86d" : "rgba(255,255,255,0.5)",
+                  border: `1px solid ${t.highlight ? "rgba(232,184,109,0.3)" : "rgba(255,255,255,0.08)"}`,
+                }}
+              >
+                {t.cta}
+              </button>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div className="text-center py-10 border-t" style={{ borderColor: "rgba(255,255,255,0.06)" }}>
+        <p className="text-xs font-mono" style={{ color: "rgba(255,255,255,0.2)" }}>
+          MAW Dashboard — Built with Oracle 🔮 | © 2026 Soul Brews Studio
+        </p>
+      </div>
+    </div>
+  );
+});

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,4 +1,5 @@
-import { memo } from "react";
+import { memo, useState } from "react";
+import { OnboardingModal } from "./OnboardingModal";
 
 const FEATURES = [
   {
@@ -61,7 +62,11 @@ const TIERS = [
 ];
 
 export const LandingPage = memo(function LandingPage({ onEnter }: { onEnter: () => void }) {
+  const [showOnboarding, setShowOnboarding] = useState(false);
+
   return (
+    <>
+    {showOnboarding && <OnboardingModal onClose={() => setShowOnboarding(false)} onEnter={onEnter} />}
     <div className="min-h-screen" style={{ background: "#0a0a0f", color: "rgba(255,255,255,0.85)" }}>
       {/* Hero */}
       <div className="flex flex-col items-center justify-center px-6 pt-20 pb-16 text-center">
@@ -144,7 +149,7 @@ export const LandingPage = memo(function LandingPage({ onEnter }: { onEnter: () 
                 ))}
               </ul>
               <button
-                onClick={onEnter}
+                onClick={() => setShowOnboarding(true)}
                 className="w-full py-2 rounded-lg font-mono text-xs transition-all hover:scale-105"
                 style={{
                   background: t.highlight ? "rgba(232,184,109,0.15)" : "rgba(255,255,255,0.05)",
@@ -166,5 +171,6 @@ export const LandingPage = memo(function LandingPage({ onEnter }: { onEnter: () 
         </p>
       </div>
     </div>
+    </>
   );
 });

--- a/src/components/MissionControl.tsx
+++ b/src/components/MissionControl.tsx
@@ -213,7 +213,7 @@ export const MissionControl = memo(function MissionControl({
         </div>
       )}
 
-      {/* Bottom left buttons — search */}
+      {/* Bottom left buttons — search + consciousness */}
       <div className="absolute bottom-4 left-6 flex items-center gap-2 z-20">
         <button
           onClick={() => mc.setShowSearch(true)}
@@ -227,6 +227,14 @@ export const MissionControl = memo(function MissionControl({
           <span className="text-[10px] font-mono">Oracle</span>
           <kbd className="text-[8px] text-white/20 ml-1">⌘K</kbd>
         </button>
+        <a
+          href="#consciousness"
+          className="flex items-center gap-2 px-3 py-2 rounded-xl bg-black/50 backdrop-blur border border-purple-500/20 text-purple-400/70 hover:text-purple-300 hover:border-purple-400/40 cursor-pointer transition-all no-underline"
+          title="Oracle Consciousness"
+        >
+          <span style={{ fontSize: 14 }}>🧠</span>
+          <span className="text-[10px] font-mono">Consciousness</span>
+        </a>
       </div>
 
       {/* Oracle Search overlay */}

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -136,26 +136,31 @@ export function MonitoringView() {
   const [loading, setLoading] = useState(true);
   const [tab, setTab] = useState<"health" | "audit" | "snapshots">("health");
 
-  const fetchAll = useCallback(async () => {
-    const [healthRes, auditRes, snapRes] = await Promise.allSettled([
-      fetch(apiUrl("/api/monitoring/health")).then(r => r.json()),
-      fetch(apiUrl("/api/monitoring/audit?limit=100")).then(r => r.json()),
-      fetch(apiUrl("/api/snapshots?limit=20")).then(r => r.json()),
-    ]);
-
-    if (healthRes.status === "fulfilled") setOracles(healthRes.value.oracles || []);
-    if (auditRes.status === "fulfilled") setAudit(auditRes.value.entries || []);
-    if (snapRes.status === "fulfilled") setSnapshots(snapRes.value.snapshots || []);
+  const fetchTab = useCallback(async (activeTab?: string) => {
+    const t = activeTab || tab;
+    if (t === "health" || loading) {
+      const res = await fetch(apiUrl("/api/monitoring/health")).then(r => r.json()).catch(() => ({}));
+      setOracles(res.oracles || []);
+    }
+    if (t === "audit" || loading) {
+      const res = await fetch(apiUrl("/api/monitoring/audit?limit=100")).then(r => r.json()).catch(() => ({}));
+      setAudit(res.entries || []);
+    }
+    if (t === "snapshots" || loading) {
+      const res = await fetch(apiUrl("/api/snapshots?limit=20")).then(r => r.json()).catch(() => ({}));
+      setSnapshots(res.snapshots || []);
+    }
     setLoading(false);
-  }, []);
+  }, [tab, loading]);
 
-  useEffect(() => { fetchAll(); }, [fetchAll]);
+  // Initial load: fetch all tabs
+  useEffect(() => { fetchTab(); }, []);
 
-  // Auto-refresh every 30s
+  // Auto-refresh active tab every 30s
   useEffect(() => {
-    const interval = setInterval(fetchAll, 30_000);
+    const interval = setInterval(() => fetchTab(tab), 30_000);
     return () => clearInterval(interval);
-  }, [fetchAll]);
+  }, [tab, fetchTab]);
 
   if (loading) {
     return (
@@ -185,7 +190,7 @@ export function MonitoringView() {
           </p>
         </div>
         <button
-          onClick={fetchAll}
+          onClick={() => fetchTab()}
           className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
           style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
         >

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -64,12 +64,12 @@ function HealthCard({ oracle }: { oracle: OracleHealth }) {
   const statusColor = isHealthy ? "#22c55e" : "#ef4444";
 
   return (
-    <div className="rounded-2xl p-5 transition-all" style={{
+    <div className="rounded-xl sm:rounded-2xl p-4 sm:p-5 transition-all" style={{
       background: isHealthy ? "rgba(34,197,94,0.04)" : "rgba(239,68,68,0.04)",
       border: `1px solid ${isHealthy ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)"}`,
     }}>
-      <div className="flex items-center gap-3 mb-4">
-        <div className="w-10 h-10 rounded-full flex items-center justify-center text-lg font-bold shrink-0" style={{ background: `${color}22`, border: `2px solid ${color}` }}>
+      <div className="flex items-center gap-2 sm:gap-3 mb-3 sm:mb-4">
+        <div className="w-8 h-8 sm:w-10 sm:h-10 rounded-full flex items-center justify-center text-base sm:text-lg font-bold shrink-0" style={{ background: `${color}22`, border: `2px solid ${color}` }}>
           {agentIcon(oracle.name + "-oracle")}
         </div>
         <div className="flex-1">
@@ -174,7 +174,7 @@ function ServerHealth({ snapshots }: { snapshots: HealthSnapshot[] }) {
   return (
     <div className="space-y-6">
       {/* Current Status Cards */}
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-2 sm:gap-4">
         <div className="rounded-2xl p-4" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
           <div className="font-mono text-[10px] mb-2" style={{ color: "rgba(255,255,255,0.3)" }}>MEMORY</div>
           <div className="font-mono text-xl font-bold mb-1" style={{ color: latest.memUsedPct > 85 ? "#ef4444" : "#22c55e" }}>
@@ -386,18 +386,18 @@ export function MonitoringView() {
   ];
 
   return (
-    <div className="px-6 py-6 max-w-6xl mx-auto">
+    <div className="px-3 sm:px-6 py-4 sm:py-6 max-w-6xl mx-auto">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex items-center justify-between mb-4 sm:mb-6">
         <div>
-          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Monitoring</h1>
-          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
-            {oracles.length} oracle{oracles.length !== 1 ? "s" : ""} tracked · auto-refresh 30s
+          <h1 className="text-xl sm:text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Monitoring</h1>
+          <p className="font-mono text-[10px] sm:text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
+            {oracles.length} oracle{oracles.length !== 1 ? "s" : ""} tracked
           </p>
         </div>
         <button
           onClick={() => fetchTab()}
-          className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
+          className="px-3 sm:px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer min-h-[44px] sm:min-h-0"
           style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
         >
           Refresh
@@ -405,12 +405,12 @@ export function MonitoringView() {
       </div>
 
       {/* Tabs */}
-      <div className="flex gap-1 mb-6 p-1 rounded-xl" style={{ background: "rgba(255,255,255,0.03)" }}>
+      <div className="flex gap-1 mb-4 sm:mb-6 p-1 rounded-xl overflow-x-auto scrollbar-hide" style={{ background: "rgba(255,255,255,0.03)", WebkitOverflowScrolling: "touch" }}>
         {tabs.map(t => (
           <button
             key={t.id}
             onClick={() => setTab(t.id)}
-            className="flex-1 py-2 px-4 rounded-lg font-mono text-xs transition-all cursor-pointer"
+            className="flex-1 py-2 px-2 sm:px-4 rounded-lg font-mono text-[11px] sm:text-xs transition-all cursor-pointer whitespace-nowrap min-h-[44px] sm:min-h-0"
             style={{
               background: tab === t.id ? "rgba(168,85,247,0.12)" : "transparent",
               color: tab === t.id ? "#c084fc" : "rgba(255,255,255,0.4)",

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,0 +1,234 @@
+import { useState, useEffect, useCallback } from "react";
+import { apiUrl } from "../lib/api";
+import { agentColor } from "../lib/constants";
+import { AgentAvatar } from "./AgentAvatar";
+
+interface OracleHealth {
+  name: string;
+  lastSeen: string;
+  totalSessions: number;
+  crashes: number;
+  lastCrash: string | null;
+  events: number;
+}
+
+interface AuditEntry {
+  timestamp?: string;
+  action?: string;
+  event?: string;
+  oracle?: string;
+  session?: string;
+  message?: string;
+  [key: string]: any;
+}
+
+interface SnapshotSummary {
+  file: string;
+  timestamp: string;
+  trigger: string;
+  sessionCount: number;
+  windowCount: number;
+}
+
+function timeAgo(ts: string | number): string {
+  const d = typeof ts === "string" ? new Date(ts) : new Date(ts);
+  const diff = Date.now() - d.getTime();
+  if (diff < 0 || isNaN(diff)) return "—";
+  if (diff < 60_000) return "just now";
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86400_000) return `${Math.floor(diff / 3600_000)}h ago`;
+  return `${Math.floor(diff / 86400_000)}d ago`;
+}
+
+function HealthCard({ oracle }: { oracle: OracleHealth }) {
+  const isHealthy = oracle.crashes === 0;
+  const color = agentColor(oracle.name + "-oracle");
+  const statusColor = isHealthy ? "#22c55e" : "#ef4444";
+
+  return (
+    <div className="rounded-2xl p-5 transition-all" style={{
+      background: isHealthy ? "rgba(34,197,94,0.04)" : "rgba(239,68,68,0.04)",
+      border: `1px solid ${isHealthy ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)"}`,
+    }}>
+      <div className="flex items-center gap-3 mb-4">
+        <AgentAvatar name={oracle.name + "-oracle"} size={40} />
+        <div className="flex-1">
+          <h3 className="font-mono font-bold" style={{ color }}>{oracle.name}</h3>
+          <div className="flex items-center gap-2 mt-0.5">
+            <div className="w-2 h-2 rounded-full" style={{ background: statusColor, boxShadow: `0 0 6px ${statusColor}` }} />
+            <span className="font-mono text-xs" style={{ color: statusColor }}>{isHealthy ? "HEALTHY" : `${oracle.crashes} CRASH${oracle.crashes > 1 ? "ES" : ""}`}</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <Stat label="Sessions" value={String(oracle.totalSessions)} />
+        <Stat label="Events" value={String(oracle.events)} />
+        <Stat label="Last seen" value={oracle.lastSeen ? timeAgo(oracle.lastSeen) : "—"} />
+        <Stat label="Last crash" value={oracle.lastCrash ? timeAgo(oracle.lastCrash) : "never"} color={oracle.lastCrash ? "#ef4444" : "#22c55e"} />
+      </div>
+    </div>
+  );
+}
+
+function Stat({ label, value, color }: { label: string; value: string; color?: string }) {
+  return (
+    <div className="rounded-lg px-3 py-2" style={{ background: "rgba(0,0,0,0.2)" }}>
+      <div className="font-mono text-[10px]" style={{ color: "rgba(255,255,255,0.3)" }}>{label}</div>
+      <div className="font-mono text-sm font-bold" style={{ color: color || "rgba(255,255,255,0.7)" }}>{value}</div>
+    </div>
+  );
+}
+
+function AuditLog({ entries }: { entries: AuditEntry[] }) {
+  if (entries.length === 0) {
+    return <p className="font-mono text-xs text-center py-8" style={{ color: "rgba(255,255,255,0.25)" }}>No audit entries</p>;
+  }
+
+  return (
+    <div className="space-y-1 max-h-96 overflow-y-auto" style={{ scrollbarWidth: "thin" }}>
+      {entries.map((entry, i) => (
+        <div key={i} className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-white/[0.02]">
+          <span className="font-mono text-[10px] shrink-0 w-16" style={{ color: "rgba(255,255,255,0.25)" }}>
+            {entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" }) : "—"}
+          </span>
+          <span className="font-mono text-xs px-2 py-0.5 rounded" style={{
+            background: entry.action === "wake" || entry.event === "SessionStart" ? "rgba(34,197,94,0.1)" :
+                        entry.action === "crash" || entry.event === "Error" ? "rgba(239,68,68,0.1)" :
+                        "rgba(255,255,255,0.04)",
+            color: entry.action === "wake" || entry.event === "SessionStart" ? "#86efac" :
+                   entry.action === "crash" || entry.event === "Error" ? "#fca5a5" : "rgba(255,255,255,0.5)",
+          }}>
+            {entry.action || entry.event || "log"}
+          </span>
+          <span className="font-mono text-xs truncate flex-1" style={{ color: "rgba(255,255,255,0.5)" }}>
+            {entry.oracle || entry.session || ""} {entry.message ? `— ${entry.message}` : ""}
+          </span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function SnapshotList({ snapshots }: { snapshots: SnapshotSummary[] }) {
+  if (snapshots.length === 0) {
+    return <p className="font-mono text-xs text-center py-8" style={{ color: "rgba(255,255,255,0.25)" }}>No snapshots</p>;
+  }
+
+  return (
+    <div className="space-y-1 max-h-64 overflow-y-auto" style={{ scrollbarWidth: "thin" }}>
+      {snapshots.map((s) => (
+        <div key={s.file} className="flex items-center gap-3 py-2 px-3 rounded-lg hover:bg-white/[0.02]">
+          <span className="text-sm">📸</span>
+          <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.5)" }}>{timeAgo(s.timestamp)}</span>
+          <span className="font-mono text-xs px-2 py-0.5 rounded" style={{ background: "rgba(168,85,247,0.08)", color: "#c084fc" }}>{s.trigger}</span>
+          <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>{s.sessionCount}s / {s.windowCount}w</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function MonitoringView() {
+  const [oracles, setOracles] = useState<OracleHealth[]>([]);
+  const [audit, setAudit] = useState<AuditEntry[]>([]);
+  const [snapshots, setSnapshots] = useState<SnapshotSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState<"health" | "audit" | "snapshots">("health");
+
+  const fetchAll = useCallback(async () => {
+    const [healthRes, auditRes, snapRes] = await Promise.allSettled([
+      fetch(apiUrl("/api/monitoring/health")).then(r => r.json()),
+      fetch(apiUrl("/api/monitoring/audit?limit=100")).then(r => r.json()),
+      fetch(apiUrl("/api/snapshots?limit=20")).then(r => r.json()),
+    ]);
+
+    if (healthRes.status === "fulfilled") setOracles(healthRes.value.oracles || []);
+    if (auditRes.status === "fulfilled") setAudit(auditRes.value.entries || []);
+    if (snapRes.status === "fulfilled") setSnapshots(snapRes.value.snapshots || []);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchAll(); }, [fetchAll]);
+
+  // Auto-refresh every 30s
+  useEffect(() => {
+    const interval = setInterval(fetchAll, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchAll]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <div className="text-center">
+          <div className="text-4xl mb-4 animate-pulse">📡</div>
+          <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>Loading monitoring data...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const tabs = [
+    { id: "health" as const, label: "Health", count: oracles.length },
+    { id: "audit" as const, label: "Audit Log", count: audit.length },
+    { id: "snapshots" as const, label: "Snapshots", count: snapshots.length },
+  ];
+
+  return (
+    <div className="px-6 py-6 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Monitoring</h1>
+          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
+            {oracles.length} oracle{oracles.length !== 1 ? "s" : ""} tracked · auto-refresh 30s
+          </p>
+        </div>
+        <button
+          onClick={fetchAll}
+          className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
+          style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {/* Tabs */}
+      <div className="flex gap-1 mb-6 p-1 rounded-xl" style={{ background: "rgba(255,255,255,0.03)" }}>
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            onClick={() => setTab(t.id)}
+            className="flex-1 py-2 px-4 rounded-lg font-mono text-xs transition-all cursor-pointer"
+            style={{
+              background: tab === t.id ? "rgba(168,85,247,0.12)" : "transparent",
+              color: tab === t.id ? "#c084fc" : "rgba(255,255,255,0.4)",
+              border: tab === t.id ? "1px solid rgba(168,85,247,0.2)" : "1px solid transparent",
+            }}
+          >
+            {t.label} ({t.count})
+          </button>
+        ))}
+      </div>
+
+      {/* Content */}
+      {tab === "health" && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {oracles.map(o => <HealthCard key={o.name} oracle={o} />)}
+        </div>
+      )}
+
+      {tab === "audit" && (
+        <div className="rounded-2xl overflow-hidden" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <AuditLog entries={audit} />
+        </div>
+      )}
+
+      {tab === "snapshots" && (
+        <div className="rounded-2xl overflow-hidden" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <SnapshotList snapshots={snapshots} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/apiFetch";
 import { agentColor } from "../lib/constants";
 import { AgentAvatar } from "./AgentAvatar";
 
@@ -139,15 +139,15 @@ export function MonitoringView() {
   const fetchTab = useCallback(async (activeTab?: string) => {
     const t = activeTab || tab;
     if (t === "health" || loading) {
-      const res = await fetch(apiUrl("/api/monitoring/health")).then(r => r.json()).catch(() => ({}));
+      const res = await apiFetch<{ oracles: OracleHealth[] }>("/api/monitoring/health").catch(() => ({ oracles: [] }));
       setOracles(res.oracles || []);
     }
     if (t === "audit" || loading) {
-      const res = await fetch(apiUrl("/api/monitoring/audit?limit=100")).then(r => r.json()).catch(() => ({}));
+      const res = await apiFetch<{ entries: AuditEntry[] }>("/api/monitoring/audit?limit=100").catch(() => ({ entries: [] }));
       setAudit(res.entries || []);
     }
     if (t === "snapshots" || loading) {
-      const res = await fetch(apiUrl("/api/snapshots?limit=20")).then(r => r.json()).catch(() => ({}));
+      const res = await apiFetch<{ snapshots: SnapshotSummary[] }>("/api/snapshots?limit=20").catch(() => ({ snapshots: [] }));
       setSnapshots(res.snapshots || []);
     }
     setLoading(false);

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiFetch } from "../lib/apiFetch";
-import { agentColor } from "../lib/constants";
-import { AgentAvatar } from "./AgentAvatar";
+import { agentColor, agentIcon } from "../lib/constants";
 
 interface OracleHealth {
   name: string;
@@ -30,6 +29,24 @@ interface SnapshotSummary {
   windowCount: number;
 }
 
+interface HealthSnapshot {
+  ts: number;
+  timestamp: string;
+  memAvailMb: number;
+  memTotalMb: number;
+  memUsedPct: number;
+  diskUsedPct: number;
+  diskAvailGb: number;
+  loadAvg: string;
+  cpuCount: number;
+  pm2Online: number;
+  pm2Total: number;
+  dockerRunning: number;
+  dockerTotal: number;
+  alertFired: number;
+  alertReason: string | null;
+}
+
 function timeAgo(ts: string | number): string {
   const d = typeof ts === "string" ? new Date(ts) : new Date(ts);
   const diff = Date.now() - d.getTime();
@@ -51,7 +68,9 @@ function HealthCard({ oracle }: { oracle: OracleHealth }) {
       border: `1px solid ${isHealthy ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.15)"}`,
     }}>
       <div className="flex items-center gap-3 mb-4">
-        <AgentAvatar name={oracle.name + "-oracle"} size={40} />
+        <div className="w-10 h-10 rounded-full flex items-center justify-center text-lg font-bold shrink-0" style={{ background: `${color}22`, border: `2px solid ${color}` }}>
+          {agentIcon(oracle.name + "-oracle")}
+        </div>
         <div className="flex-1">
           <h3 className="font-mono font-bold" style={{ color }}>{oracle.name}</h3>
           <div className="flex items-center gap-2 mt-0.5">
@@ -129,12 +148,189 @@ function SnapshotList({ snapshots }: { snapshots: SnapshotSummary[] }) {
   );
 }
 
+function MiniBar({ value, max, color, warn }: { value: number; max: number; color: string; warn?: number }) {
+  const pct = Math.min(100, (value / max) * 100);
+  const isWarn = warn !== undefined && value >= warn;
+  const barColor = isWarn ? "#ef4444" : color;
+  return (
+    <div className="w-full h-2 rounded-full overflow-hidden" style={{ background: "rgba(255,255,255,0.06)" }}>
+      <div className="h-full rounded-full transition-all" style={{ width: `${pct}%`, background: barColor }} />
+    </div>
+  );
+}
+
+function ServerHealth({ snapshots }: { snapshots: HealthSnapshot[] }) {
+  if (snapshots.length === 0) {
+    return <p className="font-mono text-xs text-center py-8" style={{ color: "rgba(255,255,255,0.25)" }}>No health data yet — waiting for first heartbeat</p>;
+  }
+
+  const latest = snapshots[0];
+  const load1 = parseFloat(latest.loadAvg.split(" ")[0] || "0");
+
+  // Build mini timeline (last 24h, reversed to chronological)
+  const timeline = [...snapshots].reverse();
+
+  return (
+    <div className="space-y-6">
+      {/* Current Status Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="rounded-2xl p-4" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <div className="font-mono text-[10px] mb-2" style={{ color: "rgba(255,255,255,0.3)" }}>MEMORY</div>
+          <div className="font-mono text-xl font-bold mb-1" style={{ color: latest.memUsedPct > 85 ? "#ef4444" : "#22c55e" }}>
+            {latest.memUsedPct}%
+          </div>
+          <MiniBar value={latest.memUsedPct} max={100} color="#8b5cf6" warn={85} />
+          <div className="font-mono text-[10px] mt-1" style={{ color: "rgba(255,255,255,0.25)" }}>
+            {latest.memAvailMb} MB free / {latest.memTotalMb} MB
+          </div>
+        </div>
+
+        <div className="rounded-2xl p-4" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <div className="font-mono text-[10px] mb-2" style={{ color: "rgba(255,255,255,0.3)" }}>DISK</div>
+          <div className="font-mono text-xl font-bold mb-1" style={{ color: latest.diskUsedPct > 90 ? "#ef4444" : "#22c55e" }}>
+            {latest.diskUsedPct}%
+          </div>
+          <MiniBar value={latest.diskUsedPct} max={100} color="#3b82f6" warn={90} />
+          <div className="font-mono text-[10px] mt-1" style={{ color: "rgba(255,255,255,0.25)" }}>
+            {latest.diskAvailGb} GB free
+          </div>
+        </div>
+
+        <div className="rounded-2xl p-4" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <div className="font-mono text-[10px] mb-2" style={{ color: "rgba(255,255,255,0.3)" }}>LOAD</div>
+          <div className="font-mono text-xl font-bold mb-1" style={{ color: load1 > latest.cpuCount ? "#ef4444" : "#22c55e" }}>
+            {latest.loadAvg.split(" ")[0]}
+          </div>
+          <MiniBar value={load1} max={latest.cpuCount * 2} color="#f59e0b" warn={latest.cpuCount} />
+          <div className="font-mono text-[10px] mt-1" style={{ color: "rgba(255,255,255,0.25)" }}>
+            {latest.loadAvg} / {latest.cpuCount} CPUs
+          </div>
+        </div>
+
+        <div className="rounded-2xl p-4" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+          <div className="font-mono text-[10px] mb-2" style={{ color: "rgba(255,255,255,0.3)" }}>SERVICES</div>
+          <div className="font-mono text-xl font-bold mb-1" style={{ color: "#22c55e" }}>
+            {latest.pm2Online + latest.dockerRunning}
+          </div>
+          <div className="flex gap-3 mt-1">
+            <div className="font-mono text-[10px]" style={{ color: "rgba(255,255,255,0.25)" }}>
+              PM2: {latest.pm2Online}/{latest.pm2Total}
+            </div>
+            <div className="font-mono text-[10px]" style={{ color: "rgba(255,255,255,0.25)" }}>
+              Docker: {latest.dockerRunning}/{latest.dockerTotal}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Timeline */}
+      <div className="rounded-2xl p-5" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+        <div className="font-mono text-[10px] mb-3" style={{ color: "rgba(255,255,255,0.3)" }}>
+          TIMELINE — last {snapshots.length} snapshots
+        </div>
+
+        {/* Memory timeline */}
+        <div className="mb-4">
+          <div className="font-mono text-[10px] mb-1" style={{ color: "#8b5cf6" }}>MEM %</div>
+          <div className="flex items-end gap-px h-12">
+            {timeline.map((s, i) => (
+              <div
+                key={i}
+                className="flex-1 rounded-t-sm transition-all min-w-[2px]"
+                style={{
+                  height: `${s.memUsedPct}%`,
+                  background: s.memUsedPct > 85 ? "#ef4444" : "#8b5cf6",
+                  opacity: 0.6,
+                }}
+                title={`${new Date(s.ts).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })} — ${s.memUsedPct}%`}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Disk timeline */}
+        <div className="mb-4">
+          <div className="font-mono text-[10px] mb-1" style={{ color: "#3b82f6" }}>DISK %</div>
+          <div className="flex items-end gap-px h-12">
+            {timeline.map((s, i) => (
+              <div
+                key={i}
+                className="flex-1 rounded-t-sm transition-all min-w-[2px]"
+                style={{
+                  height: `${s.diskUsedPct}%`,
+                  background: s.diskUsedPct > 90 ? "#ef4444" : "#3b82f6",
+                  opacity: 0.6,
+                }}
+                title={`${new Date(s.ts).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })} — ${s.diskUsedPct}%`}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Load timeline */}
+        <div>
+          <div className="font-mono text-[10px] mb-1" style={{ color: "#f59e0b" }}>LOAD</div>
+          <div className="flex items-end gap-px h-12">
+            {timeline.map((s, i) => {
+              const l = parseFloat(s.loadAvg.split(" ")[0] || "0");
+              const maxLoad = s.cpuCount * 2;
+              return (
+                <div
+                  key={i}
+                  className="flex-1 rounded-t-sm transition-all min-w-[2px]"
+                  style={{
+                    height: `${Math.min(100, (l / maxLoad) * 100)}%`,
+                    background: l > s.cpuCount ? "#ef4444" : "#f59e0b",
+                    opacity: 0.6,
+                  }}
+                  title={`${new Date(s.ts).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" })} — ${l}`}
+                />
+              );
+            })}
+          </div>
+        </div>
+
+        <div className="flex justify-between mt-2">
+          <span className="font-mono text-[9px]" style={{ color: "rgba(255,255,255,0.15)" }}>
+            {timeline.length > 0 ? new Date(timeline[0].ts).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" }) : ""}
+          </span>
+          <span className="font-mono text-[9px]" style={{ color: "rgba(255,255,255,0.15)" }}>
+            {timeline.length > 0 ? new Date(timeline[timeline.length - 1].ts).toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" }) : ""}
+          </span>
+        </div>
+      </div>
+
+      {/* Alert History */}
+      {snapshots.some(s => s.alertFired) && (
+        <div className="rounded-2xl p-5" style={{ background: "rgba(239,68,68,0.04)", border: "1px solid rgba(239,68,68,0.15)" }}>
+          <div className="font-mono text-[10px] mb-3" style={{ color: "#ef4444" }}>ALERTS</div>
+          <div className="space-y-1">
+            {snapshots.filter(s => s.alertFired).slice(0, 10).map((s, i) => (
+              <div key={i} className="flex items-center gap-3 py-1">
+                <span className="font-mono text-[10px]" style={{ color: "rgba(255,255,255,0.25)" }}>
+                  {new Date(s.ts).toLocaleString("en-GB", { month: "short", day: "2-digit", hour: "2-digit", minute: "2-digit" })}
+                </span>
+                <span className="font-mono text-xs" style={{ color: "#fca5a5" }}>{s.alertReason}</span>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <div className="font-mono text-[10px] text-right" style={{ color: "rgba(255,255,255,0.15)" }}>
+        Last updated: {new Date(latest.ts).toLocaleString("en-GB")}
+      </div>
+    </div>
+  );
+}
+
 export function MonitoringView() {
   const [oracles, setOracles] = useState<OracleHealth[]>([]);
   const [audit, setAudit] = useState<AuditEntry[]>([]);
   const [snapshots, setSnapshots] = useState<SnapshotSummary[]>([]);
+  const [healthHistory, setHealthHistory] = useState<HealthSnapshot[]>([]);
   const [loading, setLoading] = useState(true);
-  const [tab, setTab] = useState<"health" | "audit" | "snapshots">("health");
+  const [tab, setTab] = useState<"health" | "server" | "audit" | "snapshots">("health");
 
   const fetchTab = useCallback(async (activeTab?: string) => {
     const t = activeTab || tab;
@@ -149,6 +345,10 @@ export function MonitoringView() {
     if (t === "snapshots" || loading) {
       const res = await apiFetch<{ snapshots: SnapshotSummary[] }>("/api/snapshots?limit=20").catch(() => ({ snapshots: [] }));
       setSnapshots(res.snapshots || []);
+    }
+    if (t === "server" || loading) {
+      const res = await apiFetch<{ snapshots: HealthSnapshot[] }>("/api/health/history?hours=24").catch(() => ({ snapshots: [] }));
+      setHealthHistory(res.snapshots || []);
     }
     setLoading(false);
   }, [tab, loading]);
@@ -175,6 +375,7 @@ export function MonitoringView() {
 
   const tabs = [
     { id: "health" as const, label: "Health", count: oracles.length },
+    { id: "server" as const, label: "Server", count: healthHistory.length },
     { id: "audit" as const, label: "Audit Log", count: audit.length },
     { id: "snapshots" as const, label: "Snapshots", count: snapshots.length },
   ];
@@ -221,6 +422,10 @@ export function MonitoringView() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
           {oracles.map(o => <HealthCard key={o.name} oracle={o} />)}
         </div>
+      )}
+
+      {tab === "server" && (
+        <ServerHealth snapshots={healthHistory} />
       )}
 
       {tab === "audit" && (

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -1,6 +1,7 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { apiFetch } from "../lib/apiFetch";
 import { agentColor, agentIcon } from "../lib/constants";
+import { useWebSocket } from "../hooks/useWebSocket";
 
 interface OracleHealth {
   name: string;
@@ -356,11 +357,15 @@ export function MonitoringView() {
   // Initial load: fetch all tabs
   useEffect(() => { fetchTab(); }, []);
 
-  // Auto-refresh active tab every 30s
-  useEffect(() => {
-    const interval = setInterval(() => fetchTab(tab), 30_000);
-    return () => clearInterval(interval);
-  }, [tab, fetchTab]);
+  // Real-time: refetch on feed events via WebSocket (replaces 30s polling)
+  const fetchTabRef = useRef(fetchTab);
+  fetchTabRef.current = fetchTab;
+  const handleWsMessage = useCallback((msg: any) => {
+    if (msg.type === "feed" || msg.type === "maw-log") {
+      fetchTabRef.current();
+    }
+  }, []);
+  useWebSocket(handleWsMessage);
 
   if (loading) {
     return (

--- a/src/components/MonitoringView.tsx
+++ b/src/components/MonitoringView.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { apiFetch } from "../lib/apiFetch";
 import { agentColor, agentIcon } from "../lib/constants";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { PageShell } from "./PageShell";
 
 interface OracleHealth {
   name: string;
@@ -386,7 +387,7 @@ export function MonitoringView() {
   ];
 
   return (
-    <div className="px-3 sm:px-6 py-4 sm:py-6 max-w-6xl mx-auto">
+    <PageShell maxWidth="1152px">
       {/* Header */}
       <div className="flex items-center justify-between mb-4 sm:mb-6">
         <div>
@@ -444,6 +445,6 @@ export function MonitoringView() {
           <SnapshotList snapshots={snapshots} />
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/src/components/OnboardingModal.tsx
+++ b/src/components/OnboardingModal.tsx
@@ -1,0 +1,127 @@
+import { memo, useState } from "react";
+import { apiUrl } from "../lib/api";
+
+interface Trial {
+  id: string;
+  email: string;
+  tier: string;
+  status: string;
+  createdAt: number;
+  expiresAt: number;
+}
+
+export const OnboardingModal = memo(function OnboardingModal({ onClose, onEnter }: { onClose: () => void; onEnter: () => void }) {
+  const [email, setEmail] = useState("");
+  const [tier, setTier] = useState("solo");
+  const [loading, setLoading] = useState(false);
+  const [trial, setTrial] = useState<Trial | null>(null);
+  const [error, setError] = useState("");
+
+  const submit = async () => {
+    if (!email.includes("@") || email.length < 5) {
+      setError("Please enter a valid email");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const res = await fetch(apiUrl("/api/onboarding/signup"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: email.trim(), tier }),
+      });
+      const data = await res.json();
+      if (data.ok) {
+        setTrial(data.trial);
+      } else {
+        setError(data.error || "Something went wrong");
+      }
+    } catch {
+      setError("Connection failed");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4" style={{ background: "rgba(0,0,0,0.7)", backdropFilter: "blur(8px)" }}>
+      <div className="w-full max-w-md rounded-2xl p-6" style={{ background: "#12121a", border: "1px solid rgba(255,255,255,0.08)" }}>
+        {trial ? (
+          // Success state
+          <div className="text-center">
+            <div className="text-4xl mb-3">🎉</div>
+            <h2 className="text-lg font-bold mb-2" style={{ color: "#e8b86d" }}>Trial Active!</h2>
+            <p className="text-sm mb-4" style={{ color: "rgba(255,255,255,0.5)" }}>
+              {Math.ceil((trial.expiresAt - Date.now()) / (24 * 60 * 60 * 1000))} days remaining
+            </p>
+            <div className="rounded-xl p-4 mb-4 text-left" style={{ background: "rgba(255,255,255,0.03)", border: "1px solid rgba(255,255,255,0.06)" }}>
+              <div className="text-[10px] font-mono mb-2" style={{ color: "rgba(255,255,255,0.3)" }}>TRIAL DETAILS</div>
+              <div className="space-y-1 text-xs font-mono">
+                <div><span style={{ color: "rgba(255,255,255,0.4)" }}>ID:</span> <span style={{ color: "#64b5f6" }}>{trial.id.slice(0, 8)}...</span></div>
+                <div><span style={{ color: "rgba(255,255,255,0.4)" }}>Email:</span> <span style={{ color: "rgba(255,255,255,0.7)" }}>{trial.email}</span></div>
+                <div><span style={{ color: "rgba(255,255,255,0.4)" }}>Tier:</span> <span style={{ color: "#e8b86d" }}>{trial.tier}</span></div>
+              </div>
+            </div>
+            <button
+              onClick={onEnter}
+              className="w-full py-3 rounded-xl font-mono text-sm font-bold transition-all hover:scale-105"
+              style={{ background: "rgba(232,184,109,0.15)", color: "#e8b86d", border: "1px solid rgba(232,184,109,0.3)" }}
+            >
+              Enter Dashboard →
+            </button>
+          </div>
+        ) : (
+          // Sign-up form
+          <>
+            <div className="flex items-center justify-between mb-4">
+              <h2 className="text-lg font-bold" style={{ color: "#e8b86d" }}>Start Free Trial</h2>
+              <button onClick={onClose} className="text-white/30 hover:text-white/60 text-lg">✕</button>
+            </div>
+            <p className="text-xs mb-4" style={{ color: "rgba(255,255,255,0.4)" }}>
+              14 days free. No credit card required.
+            </p>
+
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              onKeyDown={(e) => e.key === "Enter" && submit()}
+              placeholder="your@email.com"
+              className="w-full mb-3 px-4 py-3 rounded-xl text-sm font-mono outline-none"
+              style={{ background: "rgba(255,255,255,0.05)", color: "rgba(255,255,255,0.8)", border: "1px solid rgba(255,255,255,0.1)" }}
+              autoFocus
+            />
+
+            <div className="flex gap-2 mb-4">
+              {["solo", "team", "fleet"].map((t) => (
+                <button
+                  key={t}
+                  onClick={() => setTier(t)}
+                  className="flex-1 py-2 rounded-lg text-xs font-mono capitalize transition-all"
+                  style={{
+                    background: tier === t ? "rgba(232,184,109,0.12)" : "rgba(255,255,255,0.03)",
+                    color: tier === t ? "#e8b86d" : "rgba(255,255,255,0.3)",
+                    border: `1px solid ${tier === t ? "rgba(232,184,109,0.2)" : "rgba(255,255,255,0.06)"}`,
+                  }}
+                >
+                  {t}
+                </button>
+              ))}
+            </div>
+
+            {error && <p className="text-xs mb-3" style={{ color: "#ef4444" }}>{error}</p>}
+
+            <button
+              onClick={submit}
+              disabled={loading}
+              className="w-full py-3 rounded-xl font-mono text-sm font-bold transition-all hover:scale-105"
+              style={{ background: "rgba(232,184,109,0.15)", color: "#e8b86d", border: "1px solid rgba(232,184,109,0.3)" }}
+            >
+              {loading ? "..." : "Start Trial"}
+            </button>
+          </>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/src/components/PageShell.tsx
+++ b/src/components/PageShell.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from 'react';
+import { LAYOUT } from '../lib/tokens';
+
+interface PageShellProps {
+  children: ReactNode;
+  /** Max-width for the container. Default: 1300px. */
+  maxWidth?: string;
+  /** Extra class names to merge onto the container. */
+  className?: string;
+}
+
+/**
+ * Standard page container — centers content with max-width + padding.
+ * Use on every top-level route component to keep layout consistent across apps.
+ */
+export function PageShell({
+  children,
+  maxWidth = LAYOUT.maxWidth,
+  className = '',
+}: PageShellProps) {
+  return (
+    <div
+      className={`mx-auto py-8 px-8 max-md:py-6 max-md:px-5 ${className}`}
+      style={{ maxWidth }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/PinLock.tsx
+++ b/src/components/PinLock.tsx
@@ -2,6 +2,12 @@ import { useState, useCallback, useEffect, useRef } from "react";
 import { apiUrl } from "../lib/api";
 
 const STORAGE_KEY = "office-unlocked";
+const TOKEN_KEY = "office-token";
+
+/** Store JWT token for API calls */
+export function getAuthToken(): string | null {
+  return localStorage.getItem(TOKEN_KEY);
+}
 
 export function PinLock({ children }: { children: React.ReactNode }) {
   const [unlocked, setUnlocked] = useState(() => sessionStorage.getItem(STORAGE_KEY) === "1");
@@ -43,6 +49,7 @@ export function PinLock({ children }: { children: React.ReactNode }) {
           .then(data => {
             if (data.ok) {
               sessionStorage.setItem(STORAGE_KEY, "1");
+              if (data.token) localStorage.setItem(TOKEN_KEY, data.token);
               window.location.hash = "mission";
               setUnlocked(true);
             } else {

--- a/src/components/PinLock.tsx
+++ b/src/components/PinLock.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect, useRef } from "react";
 import { apiUrl } from "../lib/api";
+import { LandingPage } from "./LandingPage";
 
 const STORAGE_KEY = "office-unlocked";
 const TOKEN_KEY = "office-token";
@@ -11,6 +12,7 @@ export function getAuthToken(): string | null {
 
 export function PinLock({ children }: { children: React.ReactNode }) {
   const [unlocked, setUnlocked] = useState(() => sessionStorage.getItem(STORAGE_KEY) === "1");
+  const [showPin, setShowPin] = useState(() => sessionStorage.getItem(STORAGE_KEY) === "1");
   const [pinLength, setPinLength] = useState(4);
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(true);
@@ -83,6 +85,7 @@ export function PinLock({ children }: { children: React.ReactNode }) {
   }, [unlocked, handleDigit, handleDelete]);
 
   if (unlocked) return <>{children}</>;
+  if (!showPin) return <LandingPage onEnter={() => setShowPin(true)} />;
   if (loading) return <div className="fixed inset-0" style={{ background: "#0a0a0f" }} />;
 
   const BUTTONS = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "", "0", "⌫"];

--- a/src/components/ProgressViewer.tsx
+++ b/src/components/ProgressViewer.tsx
@@ -1,4 +1,4 @@
-import { memo, useMemo } from "react";
+import { memo, useMemo, useRef, useEffect, useState, useCallback } from "react";
 import { agentColor } from "../lib/constants";
 import { describeActivity, type FeedEvent } from "../lib/feed";
 import { AgentAvatar } from "./AgentAvatar";
@@ -55,13 +55,38 @@ const EventRow = memo(function EventRow({ event }: { event: FeedEvent }) {
   );
 });
 
-const OracleTimeline = memo(function OracleTimeline({ group }: { group: OracleGroup }) {
+const OracleTimeline = memo(function OracleTimeline({
+  group,
+  expanded,
+  onToggle,
+}: {
+  group: OracleGroup;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
   const color = agentColor(group.oracle + "-oracle");
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const prevCountRef = useRef(group.events.length);
+
+  // Auto-scroll when new events arrive (only if already near bottom)
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el || !expanded) return;
+    if (group.events.length > prevCountRef.current) {
+      // Events are newest-first, so scroll to top for latest
+      el.scrollTop = 0;
+    }
+    prevCountRef.current = group.events.length;
+  }, [group.events.length, expanded]);
 
   return (
     <div className="rounded-2xl overflow-hidden" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
-      {/* Header */}
-      <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+      {/* Header — clickable to expand/collapse */}
+      <div
+        className="flex items-center gap-2 sm:gap-3 px-3 sm:px-5 py-3 sm:py-4 cursor-pointer select-none transition-colors hover:bg-white/[0.03] min-h-[52px]"
+        style={{ borderBottom: expanded ? "1px solid rgba(255,255,255,0.06)" : "none" }}
+        onClick={onToggle}
+      >
         <AgentAvatar name={group.oracle + "-oracle"} size={36} />
         <div className="flex-1">
           <h3 className="font-mono font-bold" style={{ color }}>{group.oracle}</h3>
@@ -69,22 +94,41 @@ const OracleTimeline = memo(function OracleTimeline({ group }: { group: OracleGr
             {group.currentActivity} · {timeAgo(group.lastActive)}
           </p>
         </div>
-        <div className="text-right">
+        <div className="flex items-center gap-3">
           <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>{group.events.length} events</span>
+          <span
+            className="text-xs transition-transform duration-200"
+            style={{ color: "rgba(255,255,255,0.3)", transform: expanded ? "rotate(180deg)" : "rotate(0deg)" }}
+          >
+            ▼
+          </span>
         </div>
       </div>
 
-      {/* Timeline */}
-      <div className="px-2 py-2 max-h-64 overflow-y-auto" style={{ scrollbarWidth: "thin" }}>
-        {group.events.map((event, i) => (
-          <EventRow key={`${event.ts}-${i}`} event={event} />
-        ))}
-      </div>
+      {/* Timeline — collapsible */}
+      {expanded && (
+        <div ref={scrollRef} className="px-2 py-2 max-h-64 overflow-y-auto" style={{ scrollbarWidth: "thin" }}>
+          {group.events.map((event, i) => (
+            <EventRow key={`${event.ts}-${i}`} event={event} />
+          ))}
+        </div>
+      )}
     </div>
   );
 });
 
 export function ProgressViewer({ feedEvents }: { feedEvents: FeedEvent[] }) {
+  const [expandedOracles, setExpandedOracles] = useState<Set<string>>(new Set());
+
+  const toggleOracle = useCallback((oracle: string) => {
+    setExpandedOracles((prev) => {
+      const next = new Set(prev);
+      if (next.has(oracle)) next.delete(oracle);
+      else next.add(oracle);
+      return next;
+    });
+  }, []);
+
   const groups = useMemo(() => {
     const map = new Map<string, FeedEvent[]>();
     for (const e of feedEvents) {
@@ -108,6 +152,13 @@ export function ProgressViewer({ feedEvents }: { feedEvents: FeedEvent[] }) {
     return result.sort((a, b) => b.lastActive - a.lastActive);
   }, [feedEvents]);
 
+  // Auto-expand the most recently active oracle
+  useEffect(() => {
+    if (groups.length > 0 && expandedOracles.size === 0) {
+      setExpandedOracles(new Set([groups[0].oracle]));
+    }
+  }, [groups.length > 0]); // only on first non-empty render
+
   if (groups.length === 0) {
     return (
       <div className="flex items-center justify-center h-[60vh]">
@@ -120,20 +171,37 @@ export function ProgressViewer({ feedEvents }: { feedEvents: FeedEvent[] }) {
     );
   }
 
+  const allExpanded = groups.every((g) => expandedOracles.has(g.oracle));
+
   return (
-    <div className="px-6 py-6 max-w-5xl mx-auto">
-      <div className="flex items-center justify-between mb-6">
+    <div className="px-3 sm:px-6 py-4 sm:py-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-4 sm:mb-6">
         <div>
-          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Progress</h1>
-          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
+          <h1 className="text-xl sm:text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Progress</h1>
+          <p className="font-mono text-[10px] sm:text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
             {groups.length} oracle{groups.length !== 1 ? "s" : ""} · {feedEvents.length} events
           </p>
         </div>
+        <button
+          className="font-mono text-xs px-3 py-1.5 rounded-lg transition-colors hover:bg-white/[0.06] min-h-[44px] sm:min-h-0"
+          style={{ color: "rgba(255,255,255,0.4)", border: "1px solid rgba(255,255,255,0.1)" }}
+          onClick={() => {
+            if (allExpanded) setExpandedOracles(new Set());
+            else setExpandedOracles(new Set(groups.map((g) => g.oracle)));
+          }}
+        >
+          {allExpanded ? "Collapse all" : "Expand all"}
+        </button>
       </div>
 
-      <div className="space-y-4">
+      <div className="space-y-3 sm:space-y-4">
         {groups.map((group) => (
-          <OracleTimeline key={group.oracle} group={group} />
+          <OracleTimeline
+            key={group.oracle}
+            group={group}
+            expanded={expandedOracles.has(group.oracle)}
+            onToggle={() => toggleOracle(group.oracle)}
+          />
         ))}
       </div>
     </div>

--- a/src/components/ProgressViewer.tsx
+++ b/src/components/ProgressViewer.tsx
@@ -1,0 +1,141 @@
+import { memo, useMemo } from "react";
+import { agentColor } from "../lib/constants";
+import { describeActivity, type FeedEvent } from "../lib/feed";
+import { AgentAvatar } from "./AgentAvatar";
+
+const EVENT_LABELS: Record<string, { icon: string; label: string; color: string }> = {
+  PreToolUse: { icon: "🔧", label: "Tool call", color: "#fbbf24" },
+  PostToolUse: { icon: "✅", label: "Tool done", color: "#22c55e" },
+  PostToolUseFailure: { icon: "❌", label: "Tool failed", color: "#ef4444" },
+  UserPromptSubmit: { icon: "💬", label: "User input", color: "#60a5fa" },
+  Stop: { icon: "⏸", label: "Waiting", color: "#94a3b8" },
+  SessionEnd: { icon: "🏁", label: "Session ended", color: "#64748b" },
+  SubagentStart: { icon: "🚀", label: "Subagent", color: "#c084fc" },
+  TaskCompleted: { icon: "🎯", label: "Task done", color: "#22c55e" },
+  Notification: { icon: "🔔", label: "Notification", color: "#fb923c" },
+  Error: { icon: "💥", label: "Error", color: "#ef4444" },
+};
+
+function formatTime(ts: number | string): string {
+  const d = typeof ts === "string" ? new Date(ts) : new Date(ts);
+  return d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function timeAgo(ts: number): string {
+  const diff = Date.now() - ts;
+  if (diff < 60_000) return "just now";
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  return `${Math.floor(diff / 3600_000)}h ago`;
+}
+
+interface OracleGroup {
+  oracle: string;
+  events: FeedEvent[];
+  lastActive: number;
+  currentActivity: string;
+}
+
+const EventRow = memo(function EventRow({ event }: { event: FeedEvent }) {
+  const config = EVENT_LABELS[event.event] || { icon: "📋", label: event.event, color: "#94a3b8" };
+  const message = event.message?.slice(0, 120) || describeActivity(event);
+
+  return (
+    <div className="flex items-start gap-3 py-2 px-3 rounded-lg transition-colors hover:bg-white/[0.02]">
+      <span className="text-sm mt-0.5 shrink-0">{config.icon}</span>
+      <div className="flex-1 min-w-0">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-xs font-bold" style={{ color: config.color }}>{config.label}</span>
+          <span className="font-mono text-[10px]" style={{ color: "rgba(255,255,255,0.25)" }}>{formatTime(event.timestamp || event.ts)}</span>
+        </div>
+        {message && (
+          <p className="font-mono text-xs mt-0.5 truncate" style={{ color: "rgba(255,255,255,0.5)" }}>{message}</p>
+        )}
+      </div>
+    </div>
+  );
+});
+
+const OracleTimeline = memo(function OracleTimeline({ group }: { group: OracleGroup }) {
+  const color = agentColor(group.oracle + "-oracle");
+
+  return (
+    <div className="rounded-2xl overflow-hidden" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(255,255,255,0.06)" }}>
+      {/* Header */}
+      <div className="flex items-center gap-3 px-5 py-4" style={{ borderBottom: "1px solid rgba(255,255,255,0.06)" }}>
+        <AgentAvatar name={group.oracle + "-oracle"} size={36} />
+        <div className="flex-1">
+          <h3 className="font-mono font-bold" style={{ color }}>{group.oracle}</h3>
+          <p className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>
+            {group.currentActivity} · {timeAgo(group.lastActive)}
+          </p>
+        </div>
+        <div className="text-right">
+          <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>{group.events.length} events</span>
+        </div>
+      </div>
+
+      {/* Timeline */}
+      <div className="px-2 py-2 max-h-64 overflow-y-auto" style={{ scrollbarWidth: "thin" }}>
+        {group.events.map((event, i) => (
+          <EventRow key={`${event.ts}-${i}`} event={event} />
+        ))}
+      </div>
+    </div>
+  );
+});
+
+export function ProgressViewer({ feedEvents }: { feedEvents: FeedEvent[] }) {
+  const groups = useMemo(() => {
+    const map = new Map<string, FeedEvent[]>();
+    for (const e of feedEvents) {
+      const arr = map.get(e.oracle) || [];
+      arr.push(e);
+      map.set(e.oracle, arr);
+    }
+
+    const result: OracleGroup[] = [];
+    for (const [oracle, events] of map) {
+      const sorted = [...events].sort((a, b) => (b.ts || 0) - (a.ts || 0));
+      const last = sorted[0];
+      result.push({
+        oracle,
+        events: sorted.slice(0, 30),
+        lastActive: last?.ts || 0,
+        currentActivity: describeActivity(last),
+      });
+    }
+
+    return result.sort((a, b) => b.lastActive - a.lastActive);
+  }, [feedEvents]);
+
+  if (groups.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <div className="text-center">
+          <div className="text-4xl mb-4">📊</div>
+          <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>No activity yet</p>
+          <p className="font-mono text-xs mt-2" style={{ color: "rgba(255,255,255,0.25)" }}>Feed events will appear here as agents work</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-6 py-6 max-w-5xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Progress</h1>
+          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
+            {groups.length} oracle{groups.length !== 1 ? "s" : ""} · {feedEvents.length} events
+          </p>
+        </div>
+      </div>
+
+      <div className="space-y-4">
+        {groups.map((group) => (
+          <OracleTimeline key={group.oracle} group={group} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ProgressViewer.tsx
+++ b/src/components/ProgressViewer.tsx
@@ -1,7 +1,6 @@
 import { memo, useMemo, useRef, useEffect, useState, useCallback } from "react";
-import { agentColor } from "../lib/constants";
+import { agentColor, agentIcon } from "../lib/constants";
 import { describeActivity, type FeedEvent } from "../lib/feed";
-import { AgentAvatar } from "./AgentAvatar";
 
 const EVENT_LABELS: Record<string, { icon: string; label: string; color: string }> = {
   PreToolUse: { icon: "🔧", label: "Tool call", color: "#fbbf24" },
@@ -87,7 +86,12 @@ const OracleTimeline = memo(function OracleTimeline({
         style={{ borderBottom: expanded ? "1px solid rgba(255,255,255,0.06)" : "none" }}
         onClick={onToggle}
       >
-        <AgentAvatar name={group.oracle + "-oracle"} size={36} />
+        <div
+          className="w-9 h-9 rounded-full flex items-center justify-center shrink-0 text-sm font-bold"
+          style={{ background: color, color: "#000", opacity: 0.9 }}
+        >
+          {agentIcon(group.oracle + "-oracle") || group.oracle.charAt(0).toUpperCase()}
+        </div>
         <div className="flex-1">
           <h3 className="font-mono font-bold" style={{ color }}>{group.oracle}</h3>
           <p className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>
@@ -145,7 +149,7 @@ export function ProgressViewer({ feedEvents }: { feedEvents: FeedEvent[] }) {
         oracle,
         events: sorted.slice(0, 30),
         lastActive: last?.ts || 0,
-        currentActivity: describeActivity(last),
+        currentActivity: last ? describeActivity(last) : "—",
       });
     }
 

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -1,0 +1,442 @@
+import { useState, useEffect, useCallback } from "react";
+import { apiFetch } from "../lib/apiFetch";
+
+interface ScheduleEvent {
+  id: number;
+  title: string;
+  description: string | null;
+  oracle: string | null;
+  startTime: string;
+  endTime: string | null;
+  recurrence: string | null;
+  status: string;
+  createdAt: string;
+}
+
+function timeAgo(ts: string): string {
+  const d = new Date(ts);
+  const diff = Date.now() - d.getTime();
+  if (diff < 0 || isNaN(diff)) return "upcoming";
+  if (diff < 60_000) return "just now";
+  if (diff < 3600_000) return `${Math.floor(diff / 60_000)}m ago`;
+  if (diff < 86400_000) return `${Math.floor(diff / 3600_000)}h ago`;
+  return `${Math.floor(diff / 86400_000)}d ago`;
+}
+
+function formatDate(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleDateString("en-GB", { weekday: "short", day: "2-digit", month: "short", year: "numeric" });
+  } catch {
+    return iso;
+  }
+}
+
+function formatTime(iso: string): string {
+  try {
+    const d = new Date(iso);
+    return d.toLocaleTimeString("en-GB", { hour: "2-digit", minute: "2-digit" });
+  } catch {
+    return "";
+  }
+}
+
+const STATUS_COLORS: Record<string, { bg: string; color: string; border: string }> = {
+  upcoming: { bg: "rgba(59,130,246,0.08)", color: "#60a5fa", border: "rgba(59,130,246,0.2)" },
+  active: { bg: "rgba(34,197,94,0.08)", color: "#22c55e", border: "rgba(34,197,94,0.2)" },
+  done: { bg: "rgba(100,116,139,0.08)", color: "#94a3b8", border: "rgba(100,116,139,0.2)" },
+  cancelled: { bg: "rgba(239,68,68,0.04)", color: "#ef4444", border: "rgba(239,68,68,0.15)" },
+};
+
+function StatusBadge({ status }: { status: string }) {
+  const s = STATUS_COLORS[status] || STATUS_COLORS.upcoming;
+  return (
+    <span className="font-mono text-[10px] px-2 py-0.5 rounded-md uppercase tracking-wider" style={{ background: s.bg, color: s.color, border: `1px solid ${s.border}` }}>
+      {status}
+    </span>
+  );
+}
+
+function EventCard({ event, onStatusChange, onDelete }: { event: ScheduleEvent; onStatusChange: (id: number, status: string) => void; onDelete: (id: number) => void }) {
+  const isPast = new Date(event.startTime) < new Date() && event.status === "upcoming";
+
+  return (
+    <div className="rounded-2xl p-5 transition-all" style={{
+      background: event.status === "cancelled" ? "rgba(255,255,255,0.01)" : "rgba(255,255,255,0.02)",
+      border: `1px solid ${event.status === "cancelled" ? "rgba(255,255,255,0.04)" : "rgba(255,255,255,0.06)"}`,
+      opacity: event.status === "cancelled" ? 0.5 : 1,
+    }}>
+      <div className="flex items-start gap-3">
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 mb-2">
+            <h3 className="font-mono font-bold text-sm" style={{ color: "rgba(255,255,255,0.85)" }}>{event.title}</h3>
+            <StatusBadge status={isPast ? "active" : event.status} />
+            {event.recurrence && (
+              <span className="font-mono text-[10px] px-2 py-0.5 rounded-md" style={{ background: "rgba(168,85,247,0.08)", color: "#c084fc", border: "1px solid rgba(168,85,247,0.2)" }}>
+                {event.recurrence}
+              </span>
+            )}
+          </div>
+
+          {event.description && (
+            <p className="font-mono text-xs mb-3" style={{ color: "rgba(255,255,255,0.4)" }}>{event.description}</p>
+          )}
+
+          <div className="flex items-center gap-4 flex-wrap">
+            <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.5)" }}>
+              {formatDate(event.startTime)} {formatTime(event.startTime)}
+            </span>
+            {event.endTime && (
+              <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>
+                - {formatTime(event.endTime)}
+              </span>
+            )}
+            {event.oracle && (
+              <span className="font-mono text-[10px] px-2 py-0.5 rounded-md" style={{ background: "rgba(34,211,238,0.08)", color: "#22d3ee", border: "1px solid rgba(34,211,238,0.15)" }}>
+                {event.oracle}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        {event.status !== "cancelled" && (
+          <div className="flex items-center gap-1 shrink-0">
+            {event.status === "upcoming" && (
+              <button
+                onClick={() => onStatusChange(event.id, "done")}
+                className="px-2 py-1 rounded-lg font-mono text-[10px] transition-all active:scale-95 cursor-pointer"
+                style={{ background: "rgba(34,197,94,0.08)", color: "#22c55e", border: "1px solid rgba(34,197,94,0.15)" }}
+                title="Mark done"
+              >Done</button>
+            )}
+            <button
+              onClick={() => onDelete(event.id)}
+              className="px-2 py-1 rounded-lg font-mono text-[10px] transition-all active:scale-95 cursor-pointer"
+              style={{ background: "rgba(239,68,68,0.06)", color: "#ef4444", border: "1px solid rgba(239,68,68,0.1)" }}
+              title="Cancel"
+            >Cancel</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AddEventForm({ onAdd }: { onAdd: () => void }) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const [oracle, setOracle] = useState("");
+  const [date, setDate] = useState(() => new Date().toISOString().slice(0, 10));
+  const [time, setTime] = useState("09:00");
+  const [endTime, setEndTime] = useState("");
+  const [recurrence, setRecurrence] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const handleSubmit = async () => {
+    if (!title.trim() || !date || !time) return;
+    setSaving(true);
+    try {
+      await apiFetch("/api/schedule", {
+        method: "POST",
+        body: JSON.stringify({
+          title: title.trim(),
+          description: description.trim() || null,
+          oracle: oracle.trim() || null,
+          startTime: `${date}T${time}:00`,
+          endTime: endTime ? `${date}T${endTime}:00` : null,
+          recurrence: recurrence || null,
+        }),
+      });
+      setTitle("");
+      setDescription("");
+      setOracle("");
+      setEndTime("");
+      setRecurrence("");
+      setOpen(false);
+      onAdd();
+    } catch (e) {
+      console.error("Failed to create event:", e);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        onClick={() => setOpen(true)}
+        className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
+        style={{ background: "rgba(34,197,94,0.1)", border: "1px solid rgba(34,197,94,0.2)", color: "#22c55e" }}
+      >
+        + Add Event
+      </button>
+    );
+  }
+
+  const inputStyle = "bg-black/50 border border-white/[0.08] rounded-lg px-3 py-2 text-xs font-mono text-white/80 outline-none focus:border-cyan-400/30 placeholder:text-white/15 w-full";
+
+  return (
+    <div className="rounded-2xl p-5" style={{ background: "rgba(255,255,255,0.02)", border: "1px solid rgba(34,197,94,0.15)" }}>
+      <div className="font-mono text-[10px] mb-4" style={{ color: "rgba(255,255,255,0.3)" }}>NEW EVENT</div>
+
+      <div className="space-y-3">
+        <input
+          type="text"
+          placeholder="Event title..."
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className={inputStyle}
+          autoFocus
+        />
+
+        <input
+          type="text"
+          placeholder="Description (optional)..."
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          className={inputStyle}
+        />
+
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+          <input
+            type="date"
+            value={date}
+            onChange={(e) => setDate(e.target.value)}
+            className={inputStyle}
+          />
+          <input
+            type="time"
+            value={time}
+            onChange={(e) => setTime(e.target.value)}
+            className={inputStyle}
+          />
+          <input
+            type="time"
+            placeholder="End time"
+            value={endTime}
+            onChange={(e) => setEndTime(e.target.value)}
+            className={inputStyle}
+          />
+          <input
+            type="text"
+            placeholder="Oracle (optional)"
+            value={oracle}
+            onChange={(e) => setOracle(e.target.value)}
+            className={inputStyle}
+          />
+        </div>
+
+        <div className="flex items-center gap-3">
+          <select
+            value={recurrence}
+            onChange={(e) => setRecurrence(e.target.value)}
+            className={inputStyle + " max-w-[180px]"}
+          >
+            <option value="">No recurrence</option>
+            <option value="daily">Daily</option>
+            <option value="weekly">Weekly</option>
+            <option value="monthly">Monthly</option>
+          </select>
+
+          <div className="flex-1" />
+
+          <button
+            onClick={() => setOpen(false)}
+            className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
+            style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            disabled={!title.trim() || saving}
+            className="px-4 py-2 rounded-xl font-mono text-xs font-bold transition-all active:scale-95 cursor-pointer disabled:opacity-30"
+            style={{ background: "rgba(34,197,94,0.15)", border: "1px solid rgba(34,197,94,0.25)", color: "#22c55e" }}
+          >
+            {saving ? "Saving..." : "Create"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ScheduleView() {
+  const [events, setEvents] = useState<ScheduleEvent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [filter, setFilter] = useState<"all" | "upcoming" | "done">("all");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  const fetchEvents = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      if (dateFrom) params.set("from", `${dateFrom}T00:00:00`);
+      if (dateTo) params.set("to", `${dateTo}T23:59:59`);
+      if (filter === "upcoming") params.set("status", "upcoming");
+      if (filter === "done") params.set("status", "done");
+
+      const qs = params.toString();
+      const res = await apiFetch<{ events: ScheduleEvent[] }>(`/api/schedule${qs ? `?${qs}` : ""}`);
+      setEvents(res.events || []);
+    } catch (e) {
+      console.error("Failed to fetch schedule:", e);
+      setEvents([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [filter, dateFrom, dateTo]);
+
+  useEffect(() => { fetchEvents(); }, [fetchEvents]);
+
+  const handleStatusChange = useCallback(async (id: number, status: string) => {
+    try {
+      await apiFetch(`/api/schedule/${id}`, {
+        method: "PUT",
+        body: JSON.stringify({ status }),
+      });
+      fetchEvents();
+    } catch (e) {
+      console.error("Failed to update event:", e);
+    }
+  }, [fetchEvents]);
+
+  const handleDelete = useCallback(async (id: number) => {
+    try {
+      await apiFetch(`/api/schedule/${id}`, { method: "DELETE" });
+      fetchEvents();
+    } catch (e) {
+      console.error("Failed to cancel event:", e);
+    }
+  }, [fetchEvents]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <div className="text-center">
+          <div className="text-4xl mb-4 animate-pulse">📅</div>
+          <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>Loading schedule...</p>
+        </div>
+      </div>
+    );
+  }
+
+  const filterTabs = [
+    { id: "all" as const, label: "All" },
+    { id: "upcoming" as const, label: "Upcoming" },
+    { id: "done" as const, label: "Done" },
+  ];
+
+  // Group events by date
+  const grouped = new Map<string, ScheduleEvent[]>();
+  for (const event of events) {
+    const dateKey = event.startTime.slice(0, 10);
+    const existing = grouped.get(dateKey) || [];
+    existing.push(event);
+    grouped.set(dateKey, existing);
+  }
+
+  const inputStyle = "bg-black/50 border border-white/[0.08] rounded-lg px-3 py-2 text-xs font-mono text-white/80 outline-none focus:border-cyan-400/30 placeholder:text-white/15";
+
+  return (
+    <div className="px-6 py-6 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Schedule</h1>
+          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
+            {events.length} event{events.length !== 1 ? "s" : ""}
+          </p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            onClick={() => fetchEvents()}
+            className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
+            style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
+          >
+            Refresh
+          </button>
+          <AddEventForm onAdd={fetchEvents} />
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex items-center gap-4 mb-6 flex-wrap">
+        <div className="flex gap-1 p-1 rounded-xl" style={{ background: "rgba(255,255,255,0.03)" }}>
+          {filterTabs.map(t => (
+            <button
+              key={t.id}
+              onClick={() => setFilter(t.id)}
+              className="py-2 px-4 rounded-lg font-mono text-xs transition-all cursor-pointer"
+              style={{
+                background: filter === t.id ? "rgba(168,85,247,0.12)" : "transparent",
+                color: filter === t.id ? "#c084fc" : "rgba(255,255,255,0.4)",
+                border: filter === t.id ? "1px solid rgba(168,85,247,0.2)" : "1px solid transparent",
+              }}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="flex items-center gap-2">
+          <input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+            className={inputStyle}
+            placeholder="From"
+          />
+          <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.2)" }}>-</span>
+          <input
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+            className={inputStyle}
+            placeholder="To"
+          />
+          {(dateFrom || dateTo) && (
+            <button
+              onClick={() => { setDateFrom(""); setDateTo(""); }}
+              className="font-mono text-xs px-2 py-1 rounded cursor-pointer"
+              style={{ color: "rgba(255,255,255,0.3)" }}
+            >
+              Clear
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Events List */}
+      {events.length === 0 ? (
+        <div className="text-center py-16">
+          <div className="text-4xl mb-4">📅</div>
+          <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.3)" }}>No events found</p>
+          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.15)" }}>Create your first event to get started</p>
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {Array.from(grouped.entries()).map(([dateKey, dateEvents]) => (
+            <div key={dateKey}>
+              <div className="font-mono text-[10px] uppercase tracking-widest mb-3 px-1" style={{ color: "rgba(255,255,255,0.25)" }}>
+                {formatDate(dateKey + "T00:00:00")}
+              </div>
+              <div className="space-y-2">
+                {dateEvents.map(event => (
+                  <EventCard
+                    key={event.id}
+                    event={event}
+                    onStatusChange={handleStatusChange}
+                    onDelete={handleDelete}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { apiFetch } from "../lib/apiFetch";
+import { useWebSocket } from "../hooks/useWebSocket";
 
 interface ScheduleEvent {
   id: number;
@@ -61,14 +62,14 @@ function EventCard({ event, onStatusChange, onDelete }: { event: ScheduleEvent; 
   const isPast = new Date(event.startTime) < new Date() && event.status === "upcoming";
 
   return (
-    <div className="rounded-2xl p-5 transition-all" style={{
+    <div className="rounded-xl sm:rounded-2xl p-3 sm:p-5 transition-all" style={{
       background: event.status === "cancelled" ? "rgba(255,255,255,0.01)" : "rgba(255,255,255,0.02)",
       border: `1px solid ${event.status === "cancelled" ? "rgba(255,255,255,0.04)" : "rgba(255,255,255,0.06)"}`,
       opacity: event.status === "cancelled" ? 0.5 : 1,
     }}>
-      <div className="flex items-start gap-3">
+      <div className="flex flex-col sm:flex-row sm:items-start gap-2 sm:gap-3">
         <div className="flex-1 min-w-0">
-          <div className="flex items-center gap-2 mb-2">
+          <div className="flex items-center gap-2 mb-2 flex-wrap">
             <h3 className="font-mono font-bold text-sm" style={{ color: "rgba(255,255,255,0.85)" }}>{event.title}</h3>
             <StatusBadge status={isPast ? "active" : event.status} />
             {event.recurrence && (
@@ -101,18 +102,18 @@ function EventCard({ event, onStatusChange, onDelete }: { event: ScheduleEvent; 
 
         {/* Actions */}
         {event.status !== "cancelled" && (
-          <div className="flex items-center gap-1 shrink-0">
+          <div className="flex items-center gap-1 shrink-0 self-end sm:self-start">
             {event.status === "upcoming" && (
               <button
                 onClick={() => onStatusChange(event.id, "done")}
-                className="px-2 py-1 rounded-lg font-mono text-[10px] transition-all active:scale-95 cursor-pointer"
+                className="px-3 sm:px-2 py-2 sm:py-1 rounded-lg font-mono text-[11px] sm:text-[10px] transition-all active:scale-95 cursor-pointer min-h-[44px] sm:min-h-0"
                 style={{ background: "rgba(34,197,94,0.08)", color: "#22c55e", border: "1px solid rgba(34,197,94,0.15)" }}
                 title="Mark done"
               >Done</button>
             )}
             <button
               onClick={() => onDelete(event.id)}
-              className="px-2 py-1 rounded-lg font-mono text-[10px] transition-all active:scale-95 cursor-pointer"
+              className="px-3 sm:px-2 py-2 sm:py-1 rounded-lg font-mono text-[11px] sm:text-[10px] transition-all active:scale-95 cursor-pointer min-h-[44px] sm:min-h-0"
               style={{ background: "rgba(239,68,68,0.06)", color: "#ef4444", border: "1px solid rgba(239,68,68,0.1)" }}
               title="Cancel"
             >Cancel</button>
@@ -167,10 +168,10 @@ function AddEventForm({ onAdd }: { onAdd: () => void }) {
     return (
       <button
         onClick={() => setOpen(true)}
-        className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
+        className="px-3 sm:px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer min-h-[44px] sm:min-h-0"
         style={{ background: "rgba(34,197,94,0.1)", border: "1px solid rgba(34,197,94,0.2)", color: "#22c55e" }}
       >
-        + Add Event
+        + Add
       </button>
     );
   }
@@ -291,6 +292,16 @@ export function ScheduleView() {
 
   useEffect(() => { fetchEvents(); }, [fetchEvents]);
 
+  // Real-time: refetch on schedule events via shared WebSocket
+  const fetchEventsRef = useRef(fetchEvents);
+  fetchEventsRef.current = fetchEvents;
+  const handleWsMessage = useCallback((msg: any) => {
+    if (msg.type === "feed" || msg.type === "schedule") {
+      fetchEventsRef.current();
+    }
+  }, []);
+  useWebSocket(handleWsMessage);
+
   const handleStatusChange = useCallback(async (id: number, status: string) => {
     try {
       await apiFetch(`/api/schedule/${id}`, {
@@ -341,19 +352,19 @@ export function ScheduleView() {
   const inputStyle = "bg-black/50 border border-white/[0.08] rounded-lg px-3 py-2 text-xs font-mono text-white/80 outline-none focus:border-cyan-400/30 placeholder:text-white/15";
 
   return (
-    <div className="px-6 py-6 max-w-4xl mx-auto">
+    <div className="px-3 sm:px-6 py-4 sm:py-6 max-w-4xl mx-auto">
       {/* Header */}
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4 sm:mb-6">
         <div>
-          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Schedule</h1>
-          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
-            {events.length} event{events.length !== 1 ? "s" : ""}
+          <h1 className="text-xl sm:text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Schedule</h1>
+          <p className="font-mono text-[10px] sm:text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>
+            {events.length} event{events.length !== 1 ? "s" : ""} · live
           </p>
         </div>
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-2 sm:gap-3">
           <button
             onClick={() => fetchEvents()}
-            className="px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer"
+            className="px-3 sm:px-4 py-2 rounded-xl font-mono text-xs transition-all active:scale-95 cursor-pointer min-h-[44px] sm:min-h-0"
             style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
           >
             Refresh
@@ -363,13 +374,13 @@ export function ScheduleView() {
       </div>
 
       {/* Filters */}
-      <div className="flex items-center gap-4 mb-6 flex-wrap">
-        <div className="flex gap-1 p-1 rounded-xl" style={{ background: "rgba(255,255,255,0.03)" }}>
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:gap-4 mb-4 sm:mb-6">
+        <div className="flex gap-1 p-1 rounded-xl overflow-x-auto scrollbar-hide" style={{ background: "rgba(255,255,255,0.03)", WebkitOverflowScrolling: "touch" }}>
           {filterTabs.map(t => (
             <button
               key={t.id}
               onClick={() => setFilter(t.id)}
-              className="py-2 px-4 rounded-lg font-mono text-xs transition-all cursor-pointer"
+              className="py-2 px-3 sm:px-4 rounded-lg font-mono text-xs transition-all cursor-pointer min-h-[44px] sm:min-h-0 whitespace-nowrap"
               style={{
                 background: filter === t.id ? "rgba(168,85,247,0.12)" : "transparent",
                 color: filter === t.id ? "#c084fc" : "rgba(255,255,255,0.4)",
@@ -381,26 +392,26 @@ export function ScheduleView() {
           ))}
         </div>
 
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 overflow-x-auto scrollbar-hide">
           <input
             type="date"
             value={dateFrom}
             onChange={(e) => setDateFrom(e.target.value)}
-            className={inputStyle}
+            className={inputStyle + " min-h-[44px] sm:min-h-0"}
             placeholder="From"
           />
-          <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.2)" }}>-</span>
+          <span className="font-mono text-xs shrink-0" style={{ color: "rgba(255,255,255,0.2)" }}>-</span>
           <input
             type="date"
             value={dateTo}
             onChange={(e) => setDateTo(e.target.value)}
-            className={inputStyle}
+            className={inputStyle + " min-h-[44px] sm:min-h-0"}
             placeholder="To"
           />
           {(dateFrom || dateTo) && (
             <button
               onClick={() => { setDateFrom(""); setDateTo(""); }}
-              className="font-mono text-xs px-2 py-1 rounded cursor-pointer"
+              className="font-mono text-xs px-2 py-1.5 rounded cursor-pointer min-h-[44px] sm:min-h-0 shrink-0"
               style={{ color: "rgba(255,255,255,0.3)" }}
             >
               Clear

--- a/src/components/ScheduleView.tsx
+++ b/src/components/ScheduleView.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { apiFetch } from "../lib/apiFetch";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { PageShell } from "./PageShell";
 
 interface ScheduleEvent {
   id: number;
@@ -352,7 +353,7 @@ export function ScheduleView() {
   const inputStyle = "bg-black/50 border border-white/[0.08] rounded-lg px-3 py-2 text-xs font-mono text-white/80 outline-none focus:border-cyan-400/30 placeholder:text-white/15";
 
   return (
-    <div className="px-3 sm:px-6 py-4 sm:py-6 max-w-4xl mx-auto">
+    <PageShell maxWidth="896px">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4 sm:mb-6">
         <div>
@@ -448,6 +449,6 @@ export function ScheduleView() {
           ))}
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -16,6 +16,7 @@ const SHORTCUTS = [
     ["S", "Soul Sync"],
     ["P", "Progress"],
     ["M", "Monitoring"],
+    ["C", "Schedule"],
   ]],
   ["Pinned Card", [
     ["Click agent", "Pin card + input"],

--- a/src/components/ShortcutOverlay.tsx
+++ b/src/components/ShortcutOverlay.tsx
@@ -13,6 +13,9 @@ const SHORTCUTS = [
   ]],
   ["Views", [
     ["V", "VS view"],
+    ["S", "Soul Sync"],
+    ["P", "Progress"],
+    ["M", "Monitoring"],
   ]],
   ["Pinned Card", [
     ["Click agent", "Pin card + input"],

--- a/src/components/SoulSyncDashboard.tsx
+++ b/src/components/SoulSyncDashboard.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { apiFetch } from "../lib/apiFetch";
+import { useWebSocket } from "../hooks/useWebSocket";
 
 interface SyncChild {
   name: string;
@@ -35,6 +36,16 @@ export function SoulSyncDashboard() {
   }, []);
 
   useEffect(() => { fetchStatus(); }, [fetchStatus]);
+
+  // Real-time: refetch on fleet/sync events via shared WebSocket
+  const fetchStatusRef = useRef(fetchStatus);
+  fetchStatusRef.current = fetchStatus;
+  const handleWsMessage = useCallback((msg: any) => {
+    if (msg.type === "feed" || msg.type === "soul-sync") {
+      fetchStatusRef.current();
+    }
+  }, []);
+  useWebSocket(handleWsMessage);
 
   const handleSync = async (targets?: string[]) => {
     setSyncing(targets?.[0] || "all");
@@ -76,17 +87,17 @@ export function SoulSyncDashboard() {
   }
 
   return (
-    <div className="px-6 py-6 max-w-6xl mx-auto">
+    <div className="px-3 sm:px-6 py-4 sm:py-6 max-w-6xl mx-auto">
       {/* Header */}
-      <div className="flex items-center justify-between mb-8">
+      <div className="flex items-center justify-between mb-5 sm:mb-8">
         <div>
-          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Soul Sync</h1>
-          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>Parent/child config synchronization</p>
+          <h1 className="text-xl sm:text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Soul Sync</h1>
+          <p className="font-mono text-[10px] sm:text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>Parent/child config sync</p>
         </div>
         <button
           onClick={() => setConfirmTarget([])}
           disabled={!!syncing}
-          className="px-5 py-2.5 rounded-xl font-mono text-sm transition-all active:scale-95 cursor-pointer disabled:opacity-50"
+          className="px-4 sm:px-5 py-2 sm:py-2.5 rounded-xl font-mono text-xs sm:text-sm transition-all active:scale-95 cursor-pointer disabled:opacity-50 min-h-[44px]"
           style={{ background: "rgba(168,85,247,0.15)", border: "1px solid rgba(168,85,247,0.3)", color: "#c084fc" }}
         >
           {syncing === "all" ? "Syncing..." : "Sync All"}
@@ -117,16 +128,16 @@ export function SoulSyncDashboard() {
       )}
 
       {/* Parent Hub */}
-      <div className="mb-8">
-        <div className="rounded-2xl p-6" style={{ background: "rgba(168,85,247,0.06)", border: "1px solid rgba(168,85,247,0.15)" }}>
+      <div className="mb-5 sm:mb-8">
+        <div className="rounded-xl sm:rounded-2xl p-4 sm:p-6" style={{ background: "rgba(168,85,247,0.06)", border: "1px solid rgba(168,85,247,0.15)" }}>
           <div className="flex items-center gap-3 mb-4">
-            <span className="text-2xl">🔮</span>
+            <span className="text-xl sm:text-2xl">🔮</span>
             <div>
-              <h2 className="font-mono font-bold" style={{ color: "#c084fc" }}>{tree.parent.name}</h2>
-              <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>PARENT</span>
+              <h2 className="font-mono font-bold text-sm sm:text-base" style={{ color: "#c084fc" }}>{tree.parent.name}</h2>
+              <span className="font-mono text-[10px] sm:text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>PARENT</span>
             </div>
           </div>
-          <div className="grid grid-cols-2 gap-2">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
             {Object.entries(tree.parent.config).filter(([k]) => k !== "_file" && k !== "name").map(([key, val]) => (
               <div key={key} className="px-3 py-2 rounded-lg" style={{ background: "rgba(255,255,255,0.03)" }}>
                 <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>{key}</span>
@@ -145,21 +156,21 @@ export function SoulSyncDashboard() {
       </div>
 
       {/* Children */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
         {tree.children.map((child) => {
           const sc = STATUS_COLORS[child.status];
           const isSyncing = syncing === child.name;
           return (
-            <div key={child.name} className="rounded-2xl p-5 transition-all" style={{ background: sc.bg, border: `1px solid ${sc.border}` }}>
-              <div className="flex items-center justify-between mb-4">
+            <div key={child.name} className="rounded-xl sm:rounded-2xl p-4 sm:p-5 transition-all" style={{ background: sc.bg, border: `1px solid ${sc.border}` }}>
+              <div className="flex items-center justify-between mb-3 sm:mb-4">
                 <div className="flex items-center gap-2">
                   <div className="w-2.5 h-2.5 rounded-full" style={{ background: sc.color, boxShadow: `0 0 6px ${sc.color}` }} />
-                  <h3 className="font-mono font-bold" style={{ color: sc.color }}>{child.name}</h3>
+                  <h3 className="font-mono font-bold text-sm sm:text-base" style={{ color: sc.color }}>{child.name}</h3>
                 </div>
                 <button
                   onClick={() => setConfirmTarget([child.name])}
                   disabled={!!syncing}
-                  className="px-3 py-1 rounded-lg font-mono text-xs transition-all active:scale-95 cursor-pointer disabled:opacity-50"
+                  className="px-3 py-1.5 sm:py-1 rounded-lg font-mono text-xs transition-all active:scale-95 cursor-pointer disabled:opacity-50 min-h-[44px] sm:min-h-0"
                   style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
                 >
                   {isSyncing ? "..." : "Sync"}

--- a/src/components/SoulSyncDashboard.tsx
+++ b/src/components/SoulSyncDashboard.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
-import { apiUrl } from "../lib/api";
+import { apiFetch } from "../lib/apiFetch";
 
 interface SyncChild {
   name: string;
@@ -28,8 +28,7 @@ export function SoulSyncDashboard() {
 
   const fetchStatus = useCallback(async () => {
     try {
-      const res = await fetch(apiUrl("/api/fleet/soul-sync-status"));
-      const data = await res.json();
+      const data = await apiFetch<{ tree: SyncTree | null }>("/api/fleet/soul-sync-status");
       setTree(data.tree || null);
     } catch { setTree(null); }
     setLoading(false);
@@ -41,12 +40,10 @@ export function SoulSyncDashboard() {
     setSyncing(targets?.[0] || "all");
     setSyncResult(null);
     try {
-      const res = await fetch(apiUrl("/api/fleet/soul-sync"), {
+      const data = await apiFetch<{ synced?: string[]; fields?: string[] }>("/api/fleet/soul-sync", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ targets }),
       });
-      const data = await res.json();
       setSyncResult(`Synced: ${data.synced?.join(", ") || "none"} (${data.fields?.length || 0} fields)`);
       fetchStatus();
     } catch (e: any) {

--- a/src/components/SoulSyncDashboard.tsx
+++ b/src/components/SoulSyncDashboard.tsx
@@ -1,0 +1,192 @@
+import { useState, useEffect, useCallback } from "react";
+import { apiUrl } from "../lib/api";
+
+interface SyncChild {
+  name: string;
+  status: "connected" | "missing";
+  diff: { key: string; parent: any; child: any }[];
+  config?: any;
+}
+
+interface SyncTree {
+  parent: { name: string; config: any };
+  children: SyncChild[];
+}
+
+const STATUS_COLORS = {
+  connected: { color: "#22c55e", bg: "rgba(34,197,94,0.08)", border: "rgba(34,197,94,0.25)" },
+  missing: { color: "#ef4444", bg: "rgba(239,68,68,0.08)", border: "rgba(239,68,68,0.25)" },
+  syncing: { color: "#fbbf24", bg: "rgba(251,191,36,0.08)", border: "rgba(251,191,36,0.25)" },
+};
+
+export function SoulSyncDashboard() {
+  const [tree, setTree] = useState<SyncTree | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [syncing, setSyncing] = useState<string | null>(null);
+  const [syncResult, setSyncResult] = useState<string | null>(null);
+
+  const fetchStatus = useCallback(async () => {
+    try {
+      const res = await fetch(apiUrl("/api/fleet/soul-sync-status"));
+      const data = await res.json();
+      setTree(data.tree || null);
+    } catch { setTree(null); }
+    setLoading(false);
+  }, []);
+
+  useEffect(() => { fetchStatus(); }, [fetchStatus]);
+
+  const handleSync = async (targets?: string[]) => {
+    setSyncing(targets?.[0] || "all");
+    setSyncResult(null);
+    try {
+      const res = await fetch(apiUrl("/api/fleet/soul-sync"), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ targets }),
+      });
+      const data = await res.json();
+      setSyncResult(`Synced: ${data.synced?.join(", ") || "none"} (${data.fields?.length || 0} fields)`);
+      fetchStatus();
+    } catch (e: any) {
+      setSyncResult(`Error: ${e.message}`);
+    }
+    setSyncing(null);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <div className="text-center">
+          <div className="text-4xl mb-4 animate-pulse">🔄</div>
+          <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>Loading soul-sync status...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (!tree) {
+    return (
+      <div className="flex items-center justify-center h-[60vh]">
+        <div className="text-center">
+          <div className="text-4xl mb-4">🔮</div>
+          <p className="font-mono text-sm" style={{ color: "rgba(255,255,255,0.4)" }}>No fleet tree found</p>
+          <p className="font-mono text-xs mt-2" style={{ color: "rgba(255,255,255,0.25)" }}>Configure parent/child relationships in fleet configs</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-6 py-6 max-w-6xl mx-auto">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-bold font-mono" style={{ color: "#e2e8f0" }}>Soul Sync</h1>
+          <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>Parent/child config synchronization</p>
+        </div>
+        <button
+          onClick={() => handleSync()}
+          disabled={!!syncing}
+          className="px-5 py-2.5 rounded-xl font-mono text-sm transition-all active:scale-95 cursor-pointer disabled:opacity-50"
+          style={{ background: "rgba(168,85,247,0.15)", border: "1px solid rgba(168,85,247,0.3)", color: "#c084fc" }}
+        >
+          {syncing === "all" ? "Syncing..." : "Sync All"}
+        </button>
+      </div>
+
+      {/* Sync result toast */}
+      {syncResult && (
+        <div className="mb-6 px-4 py-3 rounded-xl font-mono text-sm" style={{ background: "rgba(34,197,94,0.08)", border: "1px solid rgba(34,197,94,0.2)", color: "#86efac" }}>
+          {syncResult}
+        </div>
+      )}
+
+      {/* Parent Hub */}
+      <div className="mb-8">
+        <div className="rounded-2xl p-6" style={{ background: "rgba(168,85,247,0.06)", border: "1px solid rgba(168,85,247,0.15)" }}>
+          <div className="flex items-center gap-3 mb-4">
+            <span className="text-2xl">🔮</span>
+            <div>
+              <h2 className="font-mono font-bold" style={{ color: "#c084fc" }}>{tree.parent.name}</h2>
+              <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.3)" }}>PARENT</span>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            {Object.entries(tree.parent.config).filter(([k]) => k !== "_file" && k !== "name").map(([key, val]) => (
+              <div key={key} className="px-3 py-2 rounded-lg" style={{ background: "rgba(255,255,255,0.03)" }}>
+                <span className="font-mono text-xs" style={{ color: "rgba(255,255,255,0.35)" }}>{key}</span>
+                <div className="font-mono text-xs mt-0.5 truncate" style={{ color: "rgba(255,255,255,0.7)" }}>
+                  {typeof val === "object" ? JSON.stringify(val).slice(0, 60) : String(val)}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Connection lines visual */}
+      <div className="flex justify-center mb-4">
+        <div className="w-px h-8" style={{ background: "rgba(168,85,247,0.3)" }} />
+      </div>
+
+      {/* Children */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+        {tree.children.map((child) => {
+          const sc = STATUS_COLORS[child.status];
+          const isSyncing = syncing === child.name;
+          return (
+            <div key={child.name} className="rounded-2xl p-5 transition-all" style={{ background: sc.bg, border: `1px solid ${sc.border}` }}>
+              <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center gap-2">
+                  <div className="w-2.5 h-2.5 rounded-full" style={{ background: sc.color, boxShadow: `0 0 6px ${sc.color}` }} />
+                  <h3 className="font-mono font-bold" style={{ color: sc.color }}>{child.name}</h3>
+                </div>
+                <button
+                  onClick={() => handleSync([child.name])}
+                  disabled={!!syncing}
+                  className="px-3 py-1 rounded-lg font-mono text-xs transition-all active:scale-95 cursor-pointer disabled:opacity-50"
+                  style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}
+                >
+                  {isSyncing ? "..." : "Sync"}
+                </button>
+              </div>
+
+              {child.status === "missing" ? (
+                <p className="font-mono text-xs" style={{ color: "rgba(239,68,68,0.7)" }}>Config not found</p>
+              ) : child.diff.length === 0 ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-sm">✓</span>
+                  <span className="font-mono text-xs" style={{ color: "rgba(34,197,94,0.7)" }}>In sync</span>
+                </div>
+              ) : (
+                <div className="space-y-2">
+                  <span className="font-mono text-xs" style={{ color: "rgba(251,191,36,0.7)" }}>{child.diff.length} difference{child.diff.length > 1 ? "s" : ""}</span>
+                  {child.diff.map((d) => (
+                    <div key={d.key} className="rounded-lg px-3 py-2" style={{ background: "rgba(0,0,0,0.2)" }}>
+                      <div className="font-mono text-xs font-bold" style={{ color: "rgba(255,255,255,0.5)" }}>{d.key}</div>
+                      <div className="flex gap-4 mt-1">
+                        <div className="flex-1">
+                          <span className="font-mono text-[10px]" style={{ color: "rgba(168,85,247,0.5)" }}>parent</span>
+                          <div className="font-mono text-xs truncate" style={{ color: "rgba(255,255,255,0.6)" }}>
+                            {typeof d.parent === "object" ? JSON.stringify(d.parent).slice(0, 40) : String(d.parent ?? "—")}
+                          </div>
+                        </div>
+                        <div className="flex-1">
+                          <span className="font-mono text-[10px]" style={{ color: sc.color + "80" }}>child</span>
+                          <div className="font-mono text-xs truncate" style={{ color: "rgba(255,255,255,0.6)" }}>
+                            {typeof d.child === "object" ? JSON.stringify(d.child).slice(0, 40) : String(d.child ?? "—")}
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/SoulSyncDashboard.tsx
+++ b/src/components/SoulSyncDashboard.tsx
@@ -24,6 +24,7 @@ export function SoulSyncDashboard() {
   const [loading, setLoading] = useState(true);
   const [syncing, setSyncing] = useState<string | null>(null);
   const [syncResult, setSyncResult] = useState<string | null>(null);
+  const [confirmTarget, setConfirmTarget] = useState<string[] | null>(null);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -86,7 +87,7 @@ export function SoulSyncDashboard() {
           <p className="font-mono text-xs mt-1" style={{ color: "rgba(255,255,255,0.4)" }}>Parent/child config synchronization</p>
         </div>
         <button
-          onClick={() => handleSync()}
+          onClick={() => setConfirmTarget([])}
           disabled={!!syncing}
           className="px-5 py-2.5 rounded-xl font-mono text-sm transition-all active:scale-95 cursor-pointer disabled:opacity-50"
           style={{ background: "rgba(168,85,247,0.15)", border: "1px solid rgba(168,85,247,0.3)", color: "#c084fc" }}
@@ -94,6 +95,22 @@ export function SoulSyncDashboard() {
           {syncing === "all" ? "Syncing..." : "Sync All"}
         </button>
       </div>
+
+      {/* Confirmation dialog */}
+      {confirmTarget !== null && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm" onClick={() => setConfirmTarget(null)}>
+          <div className="rounded-2xl p-6 max-w-sm w-full mx-4" style={{ background: "#0a0a0f", border: "1px solid rgba(168,85,247,0.2)" }} onClick={e => e.stopPropagation()}>
+            <h3 className="font-mono font-bold text-lg mb-2" style={{ color: "#e2e8f0" }}>Confirm Sync</h3>
+            <p className="font-mono text-sm mb-6" style={{ color: "rgba(255,255,255,0.5)" }}>
+              Sync parent config to <span style={{ color: "#c084fc" }}>{confirmTarget.length ? confirmTarget.join(", ") : "all children"}</span>? This will overwrite child configs.
+            </p>
+            <div className="flex gap-3 justify-end">
+              <button onClick={() => setConfirmTarget(null)} className="px-4 py-2 rounded-xl font-mono text-sm cursor-pointer" style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}>Cancel</button>
+              <button onClick={() => { const t = confirmTarget.length ? confirmTarget : undefined; setConfirmTarget(null); handleSync(t); }} className="px-4 py-2 rounded-xl font-mono text-sm cursor-pointer" style={{ background: "rgba(168,85,247,0.15)", border: "1px solid rgba(168,85,247,0.3)", color: "#c084fc" }}>Sync</button>
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Sync result toast */}
       {syncResult && (
@@ -143,7 +160,7 @@ export function SoulSyncDashboard() {
                   <h3 className="font-mono font-bold" style={{ color: sc.color }}>{child.name}</h3>
                 </div>
                 <button
-                  onClick={() => handleSync([child.name])}
+                  onClick={() => setConfirmTarget([child.name])}
                   disabled={!!syncing}
                   className="px-3 py-1 rounded-lg font-mono text-xs transition-all active:scale-95 cursor-pointer disabled:opacity-50"
                   style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.1)", color: "rgba(255,255,255,0.5)" }}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -80,6 +80,7 @@ const NAV_ITEMS = [
   { href: "#progress", label: "Progress", id: "progress" },
   { href: "#monitoring", label: "Monitor", id: "monitoring" },
   { href: "#consciousness", label: "🧠 Think", id: "consciousness" },
+  { href: "#schedule", label: "Schedule", id: "schedule" },
   { href: "#config", label: "Config", id: "config" },
 ];
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,5 +1,6 @@
 import { memo, useState, useEffect, useRef, type ReactNode } from "react";
 import { apiUrl, isRemote } from "../lib/api";
+import { cached } from "../lib/cache";
 import { SOUND_PROFILES, getSoundProfile, setSoundProfile, previewSound, type SoundProfile } from "../lib/sounds";
 
 function SoundButton({ muted, onToggleMute }: { muted: boolean; onToggleMute: () => void }) {
@@ -99,7 +100,12 @@ function useTokenRate() {
   const [lastHourRate, setLastHourRate] = useState<RateData | null>(null);
   useEffect(() => {
     const fetch_ = () => {
-      fetch(apiUrl("/api/tokens/rate?mode=window&window=3600")).then(r => r.json()).then(d => setLastHourRate(d)).catch(() => {});
+      cached(
+        "tokens-rate-1h",
+        30_000,
+        () => fetch(apiUrl("/api/tokens/rate?mode=window&window=3600")).then(r => r.json() as Promise<RateData>),
+        { tag: "tokens-rate" },
+      ).then(setLastHourRate).catch(() => {});
     };
     fetch_();
     const iv = setInterval(fetch_, 30000);

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,6 +1,5 @@
 import { memo, useState, useEffect, useRef, type ReactNode } from "react";
 import { apiUrl, isRemote } from "../lib/api";
-import { cached } from "../lib/cache";
 import { SOUND_PROFILES, getSoundProfile, setSoundProfile, previewSound, type SoundProfile } from "../lib/sounds";
 
 function SoundButton({ muted, onToggleMute }: { muted: boolean; onToggleMute: () => void }) {
@@ -87,51 +86,11 @@ const NAV_ITEMS = [
 
 const isTouch = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
 
-function formatTokens(n: number): string {
-  if (n >= 1_000_000_000) return `${(n / 1_000_000_000).toFixed(1)}B`;
-  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
-  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
-  return `${n}`;
-}
-
-interface RateData { inputTokens: number; outputTokens: number; totalTokens: number; totalPerMin: number; inputPerMin: number; outputPerMin: number; turns: number }
-
-// Module-level kill switch — survives remounts, gates all network attempts.
-// TODO: remove + migrate to /api/costs once FORGE/Neo fix the handler
-// (currently returns `{"error":"cannot reach maw server"}` despite handler
-// in src/api/costs.ts:185). See outbox 2026-04-20_0902_to-neo_api-costs-broken.md.
-let tokenRateGone = false;
-
-function useTokenRate() {
-  const [lastHourRate, setLastHourRate] = useState<RateData | null>(null);
-  useEffect(() => {
-    if (tokenRateGone) return;
-    let cancelled = false;
-    const fetch_ = async () => {
-      if (tokenRateGone || cancelled) return;
-      try {
-        // Intentionally NOT wrapped in cached() — SWR bg refresh would keep
-        // retrying the dead endpoint. Direct fetch gives us clean one-shot control.
-        const r = await fetch(apiUrl("/api/tokens/rate?mode=window&window=3600"));
-        if (r.status === 410) {
-          tokenRateGone = true;
-          console.warn("[tokens-rate] endpoint 410 Gone — polling stopped until /api/costs is live");
-          return;
-        }
-        if (!r.ok) return;
-        const data = (await r.json()) as RateData;
-        if (!cancelled) setLastHourRate(data);
-      } catch { /* silent */ }
-    };
-    fetch_();
-    const iv = setInterval(fetch_, 30000);
-    return () => { cancelled = true; clearInterval(iv); };
-  }, []);
-  return { lastHourRate };
-}
+// Rate widget removed 2026-04-20 — /api/tokens/rate returns 410 Gone (FORGE deprecation),
+// replacement /api/costs currently returns error. Restore when backend is fixed:
+// see ψ/outbox/2026-04-20_0902_to-neo_api-costs-broken.md for context.
 
 export const StatusBar = memo(function StatusBar({ connected, agentCount, sessionCount, tabCount = 0, activeView = "office", askCount = 0, onInbox, onJump, muted, onToggleMute, children }: StatusBarProps) {
-  const { lastHourRate } = useTokenRate();
   return (
     <header className="sticky top-0 z-20 flex flex-wrap items-center gap-x-2 sm:gap-x-3 gap-y-1.5 sm:gap-y-2 mx-2 sm:mx-4 md:mx-6 mt-2 sm:mt-3 px-3 sm:px-4 md:px-6 py-2 sm:py-2.5 rounded-xl sm:rounded-2xl bg-black/50 backdrop-blur-xl border border-white/[0.06] shadow-[0_4px_30px_rgba(0,0,0,0.4)]">
       <a href="#office" className="text-sm sm:text-base md:text-lg font-bold tracking-[3px] sm:tracking-[4px] md:tracking-[6px] text-cyan-400 uppercase whitespace-nowrap hover:text-cyan-300 transition-colors">
@@ -163,13 +122,6 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
       <span className="text-[10px] text-white/20 font-mono whitespace-nowrap hidden md:inline">
         v{__MAW_VERSION__} · {__MAW_BUILD__}
       </span>
-
-      {lastHourRate && lastHourRate.totalTokens > 0 && (
-        <span className="text-[10px] font-mono whitespace-nowrap items-center gap-1 hidden sm:flex" title={`Last 60min — ${formatTokens(lastHourRate.inputTokens)} in · ${formatTokens(lastHourRate.outputTokens)} out · ${lastHourRate.turns} turns`}>
-          <span className="text-amber-400/70">{formatTokens(lastHourRate.totalPerMin)}</span>
-          <span className="text-white/15">tok/min</span>
-        </span>
-      )}
 
       {/* View-specific controls injected by parent */}
       {children}

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -111,39 +111,39 @@ function useTokenRate() {
 export const StatusBar = memo(function StatusBar({ connected, agentCount, sessionCount, tabCount = 0, activeView = "office", askCount = 0, onInbox, onJump, muted, onToggleMute, children }: StatusBarProps) {
   const { lastHourRate } = useTokenRate();
   return (
-    <header className="sticky top-0 z-20 flex flex-wrap items-center gap-x-3 gap-y-2 mx-4 sm:mx-6 mt-3 px-4 sm:px-6 py-2.5 rounded-2xl bg-black/50 backdrop-blur-xl border border-white/[0.06] shadow-[0_4px_30px_rgba(0,0,0,0.4)]">
-      <a href="#office" className="text-base sm:text-lg font-bold tracking-[4px] sm:tracking-[6px] text-cyan-400 uppercase whitespace-nowrap hover:text-cyan-300 transition-colors">
-        ARRA Office
+    <header className="sticky top-0 z-20 flex flex-wrap items-center gap-x-2 sm:gap-x-3 gap-y-1.5 sm:gap-y-2 mx-2 sm:mx-4 md:mx-6 mt-2 sm:mt-3 px-3 sm:px-4 md:px-6 py-2 sm:py-2.5 rounded-xl sm:rounded-2xl bg-black/50 backdrop-blur-xl border border-white/[0.06] shadow-[0_4px_30px_rgba(0,0,0,0.4)]">
+      <a href="#office" className="text-sm sm:text-base md:text-lg font-bold tracking-[3px] sm:tracking-[4px] md:tracking-[6px] text-cyan-400 uppercase whitespace-nowrap hover:text-cyan-300 transition-colors">
+        ARRA
       </a>
 
-      <span className="flex items-center gap-1.5 text-sm text-white/70">
+      <span className="flex items-center gap-1 sm:gap-1.5 text-xs sm:text-sm text-white/70">
         <span className={`w-2 h-2 rounded-full flex-shrink-0 ${connected ? "bg-emerald-400 shadow-[0_0_6px_#4caf50]" : "bg-red-400 animate-pulse"}`} />
         {connected ? "LIVE" : "..."}
       </span>
 
       {isRemote && (
-        <span className="text-[10px] font-mono px-2 py-0.5 rounded-md whitespace-nowrap" style={{ background: "rgba(251,191,36,0.12)", color: "#fbbf24", border: "1px solid rgba(251,191,36,0.2)" }}>
+        <span className="text-[10px] font-mono px-2 py-0.5 rounded-md whitespace-nowrap hidden sm:inline" style={{ background: "rgba(251,191,36,0.12)", color: "#fbbf24", border: "1px solid rgba(251,191,36,0.2)" }}>
           {new URLSearchParams(window.location.search).get("host")}
         </span>
       )}
 
-      <span className="text-sm text-white/70 whitespace-nowrap">
-        <strong className="text-cyan-400">{agentCount}</strong> agents
+      <span className="text-xs sm:text-sm text-white/70 whitespace-nowrap">
+        <strong className="text-cyan-400">{agentCount}</strong><span className="hidden sm:inline"> agents</span><span className="sm:hidden">a</span>
       </span>
-      <span className="text-sm text-white/70 whitespace-nowrap">
-        <strong className="text-purple-400">{sessionCount}</strong> rooms
+      <span className="text-xs sm:text-sm text-white/70 whitespace-nowrap">
+        <strong className="text-purple-400">{sessionCount}</strong><span className="hidden sm:inline"> rooms</span><span className="sm:hidden">r</span>
       </span>
       {tabCount > 0 && (
-        <span className="text-sm text-white/70 whitespace-nowrap">
+        <span className="text-xs sm:text-sm text-white/70 whitespace-nowrap hidden sm:inline">
           <strong className="text-green-400">{tabCount}</strong> tabs
         </span>
       )}
-      <span className="text-[10px] text-white/20 font-mono whitespace-nowrap">
+      <span className="text-[10px] text-white/20 font-mono whitespace-nowrap hidden md:inline">
         v{__MAW_VERSION__} · {__MAW_BUILD__}
       </span>
 
       {lastHourRate && lastHourRate.totalTokens > 0 && (
-        <span className="text-[10px] font-mono whitespace-nowrap flex items-center gap-1" title={`Last 60min — ${formatTokens(lastHourRate.inputTokens)} in · ${formatTokens(lastHourRate.outputTokens)} out · ${lastHourRate.turns} turns`}>
+        <span className="text-[10px] font-mono whitespace-nowrap items-center gap-1 hidden sm:flex" title={`Last 60min — ${formatTokens(lastHourRate.inputTokens)} in · ${formatTokens(lastHourRate.outputTokens)} out · ${lastHourRate.turns} turns`}>
           <span className="text-amber-400/70">{formatTokens(lastHourRate.totalPerMin)}</span>
           <span className="text-white/15">tok/min</span>
         </span>
@@ -157,7 +157,7 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
       {isTouch && onJump && (
         <button
           onClick={onJump}
-          className="px-3 py-1.5 rounded-lg text-xs font-mono font-bold active:scale-95 transition-all whitespace-nowrap"
+          className="px-2 sm:px-3 py-1.5 rounded-lg text-xs font-mono font-bold active:scale-95 transition-all whitespace-nowrap min-h-[44px] sm:min-h-0"
           style={{ background: "rgba(34,211,238,0.15)", color: "#22d3ee", border: "1px solid rgba(34,211,238,0.25)" }}
           title="Jump to agent (⌘J)"
         >
@@ -165,9 +165,9 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
         </button>
       )}
 
-      <nav className={`${isTouch && onJump ? "" : "ml-auto "}flex items-center gap-3 sm:gap-4 text-sm overflow-x-auto max-w-full scrollbar-hide`} style={{ WebkitOverflowScrolling: "touch" }}>
+      <nav className={`${isTouch && onJump ? "" : "ml-auto "}flex items-center gap-1 sm:gap-3 md:gap-4 text-xs sm:text-sm overflow-x-auto max-w-full scrollbar-hide pb-safe`} style={{ WebkitOverflowScrolling: "touch" }}>
         {onInbox && (
-          <button onClick={onInbox} className="relative transition-colors whitespace-nowrap text-white/50 hover:text-white/80 cursor-pointer" title="Inbox (i)">
+          <button onClick={onInbox} className="relative transition-colors whitespace-nowrap text-white/50 hover:text-white/80 cursor-pointer min-h-[44px] sm:min-h-0 px-1.5 sm:px-0 flex items-center" title="Inbox (i)">
             Inbox
             {askCount > 0 && (
               <span className="absolute -top-1.5 -right-3 min-w-[18px] h-[18px] flex items-center justify-center rounded-full text-[10px] font-bold text-white bg-red-500 animate-pulse shadow-[0_0_8px_rgba(239,68,68,0.6)]">
@@ -180,7 +180,7 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
           <a
             key={item.id}
             href={item.href}
-            className={`transition-colors whitespace-nowrap ${
+            className={`transition-colors whitespace-nowrap min-h-[44px] sm:min-h-0 px-1.5 sm:px-0 flex items-center ${
               activeView === item.id
                 ? "text-cyan-400 font-bold"
                 : "text-white/50 hover:text-white/80"

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -99,17 +99,35 @@ interface RateData { inputTokens: number; outputTokens: number; totalTokens: num
 function useTokenRate() {
   const [lastHourRate, setLastHourRate] = useState<RateData | null>(null);
   useEffect(() => {
-    const fetch_ = () => {
-      cached(
-        "tokens-rate-1h",
-        30_000,
-        () => fetch(apiUrl("/api/tokens/rate?mode=window&window=3600")).then(r => r.json() as Promise<RateData>),
-        { tag: "tokens-rate" },
-      ).then(setLastHourRate).catch(() => {});
+    let stopped = false;
+    let warned = false;
+    const fetch_ = async () => {
+      if (stopped) return;
+      try {
+        const data = await cached(
+          "tokens-rate-1h",
+          30_000,
+          async () => {
+            const r = await fetch(apiUrl("/api/tokens/rate?mode=window&window=3600"));
+            // TODO: migrate to /api/costs once FORGE/Neo fix the handler (currently returns
+            // `{"error":"cannot reach maw server"}` despite handler in src/api/costs.ts:185).
+            // Until then: stop polling on 410 Gone to keep console clean.
+            if (r.status === 410) {
+              if (!warned) { console.warn("[tokens-rate] endpoint 410 Gone — polling stopped until /api/costs is live"); warned = true; }
+              stopped = true;
+              return null;
+            }
+            if (!r.ok) return null;
+            return r.json() as Promise<RateData>;
+          },
+          { tag: "tokens-rate" },
+        );
+        if (data) setLastHourRate(data);
+      } catch { /* silent */ }
     };
     fetch_();
     const iv = setInterval(fetch_, 30000);
-    return () => clearInterval(iv);
+    return () => { stopped = true; clearInterval(iv); };
   }, []);
   return { lastHourRate };
 }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -76,6 +76,9 @@ const NAV_ITEMS = [
   { href: "#terminal", label: "Terminal", id: "terminal" },
   { href: "#chat", label: "Chat", id: "chat" },
   { href: "#teams", label: "Teams", id: "teams" },
+  { href: "#soul-sync", label: "Sync", id: "soul-sync" },
+  { href: "#progress", label: "Progress", id: "progress" },
+  { href: "#monitoring", label: "Monitor", id: "monitoring" },
   { href: "#config", label: "Config", id: "config" },
 ];
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -79,6 +79,7 @@ const NAV_ITEMS = [
   { href: "#soul-sync", label: "Sync", id: "soul-sync" },
   { href: "#progress", label: "Progress", id: "progress" },
   { href: "#monitoring", label: "Monitor", id: "monitoring" },
+  { href: "#consciousness", label: "🧠 Think", id: "consciousness" },
   { href: "#config", label: "Config", id: "config" },
 ];
 

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -96,38 +96,36 @@ function formatTokens(n: number): string {
 
 interface RateData { inputTokens: number; outputTokens: number; totalTokens: number; totalPerMin: number; inputPerMin: number; outputPerMin: number; turns: number }
 
+// Module-level kill switch — survives remounts, gates all network attempts.
+// TODO: remove + migrate to /api/costs once FORGE/Neo fix the handler
+// (currently returns `{"error":"cannot reach maw server"}` despite handler
+// in src/api/costs.ts:185). See outbox 2026-04-20_0902_to-neo_api-costs-broken.md.
+let tokenRateGone = false;
+
 function useTokenRate() {
   const [lastHourRate, setLastHourRate] = useState<RateData | null>(null);
   useEffect(() => {
-    let stopped = false;
-    let warned = false;
+    if (tokenRateGone) return;
+    let cancelled = false;
     const fetch_ = async () => {
-      if (stopped) return;
+      if (tokenRateGone || cancelled) return;
       try {
-        const data = await cached(
-          "tokens-rate-1h",
-          30_000,
-          async () => {
-            const r = await fetch(apiUrl("/api/tokens/rate?mode=window&window=3600"));
-            // TODO: migrate to /api/costs once FORGE/Neo fix the handler (currently returns
-            // `{"error":"cannot reach maw server"}` despite handler in src/api/costs.ts:185).
-            // Until then: stop polling on 410 Gone to keep console clean.
-            if (r.status === 410) {
-              if (!warned) { console.warn("[tokens-rate] endpoint 410 Gone — polling stopped until /api/costs is live"); warned = true; }
-              stopped = true;
-              return null;
-            }
-            if (!r.ok) return null;
-            return r.json() as Promise<RateData>;
-          },
-          { tag: "tokens-rate" },
-        );
-        if (data) setLastHourRate(data);
+        // Intentionally NOT wrapped in cached() — SWR bg refresh would keep
+        // retrying the dead endpoint. Direct fetch gives us clean one-shot control.
+        const r = await fetch(apiUrl("/api/tokens/rate?mode=window&window=3600"));
+        if (r.status === 410) {
+          tokenRateGone = true;
+          console.warn("[tokens-rate] endpoint 410 Gone — polling stopped until /api/costs is live");
+          return;
+        }
+        if (!r.ok) return;
+        const data = (await r.json()) as RateData;
+        if (!cancelled) setLastHourRate(data);
       } catch { /* silent */ }
     };
     fetch_();
     const iv = setInterval(fetch_, 30000);
-    return () => { stopped = true; clearInterval(iv); };
+    return () => { cancelled = true; clearInterval(iv); };
   }, []);
   return { lastHourRate };
 }

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -164,7 +164,7 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
         </button>
       )}
 
-      <nav className={`${isTouch && onJump ? "" : "ml-auto "}flex items-center gap-3 sm:gap-4 text-sm`}>
+      <nav className={`${isTouch && onJump ? "" : "ml-auto "}flex items-center gap-3 sm:gap-4 text-sm overflow-x-auto max-w-full scrollbar-hide`} style={{ WebkitOverflowScrolling: "touch" }}>
         {onInbox && (
           <button onClick={onInbox} className="relative transition-colors whitespace-nowrap text-white/50 hover:text-white/80 cursor-pointer" title="Inbox (i)">
             Inbox

--- a/src/components/TerminalKeyBar.tsx
+++ b/src/components/TerminalKeyBar.tsx
@@ -1,0 +1,67 @@
+// Mobile on-screen control-key bar for driving interactive TUIs (claude
+// multi-selects, skill prompts) from a phone. Mobile soft keyboards cannot send
+// Arrow / Enter / Tab / Esc to xterm.js, so interactive Oracle TUIs are
+// unusable on mobile without this (Boss hit it live driving Nari's HR-migration
+// scope prompt, 2026-06-06).
+//
+// Each button sends a RAW key sequence through the SAME shared-dashboard `send`
+// command the mobile composer already uses ({type:"send", text, force:true}).
+// The server-side `sendKeys` (maw-js core/transport/ssh.ts) maps these raw
+// sequences to tmux key names with NO Enter appended:
+//   \x1b[A→Up  \x1b[B→Down  \x1b[C→Right  \x1b[D→Left  \r→Enter  \x1b→Escape
+// Tab (\t) and Space (0x20) go through tmux send-text as literals; Ctrl-C
+// (\x03) is the same raw sequence the existing sleep/interrupt handler sends.
+// So no server change is needed — this is a pure tap→existing-PTY-path wiring.
+//
+// onMouseDown preventDefault keeps the composer textarea focused so tapping a
+// key never dismisses the soft keyboard. sm:hidden = mobile/touch only; desktop
+// has a physical keyboard and doesn't need it.
+
+interface KeyDef {
+  label: string;
+  seq: string;
+  title: string;
+  accent?: boolean; // Enter — the commit action
+  danger?: boolean; // Ctrl-C — interrupt
+}
+
+const KEYS: KeyDef[] = [
+  { label: "↑", seq: "\x1b[A", title: "Up" },
+  { label: "↓", seq: "\x1b[B", title: "Down" },
+  { label: "←", seq: "\x1b[D", title: "Left" },
+  { label: "→", seq: "\x1b[C", title: "Right" },
+  { label: "Enter", seq: "\r", title: "Enter / select", accent: true },
+  { label: "Tab", seq: "\t", title: "Tab" },
+  { label: "Esc", seq: "\x1b", title: "Escape" },
+  { label: "␣", seq: " ", title: "Space" },
+  { label: "⌃C", seq: "\x03", title: "Ctrl-C (interrupt)", danger: true },
+];
+
+export function TerminalKeyBar({ onKey }: { onKey: (seq: string) => void }) {
+  return (
+    <div
+      className="sm:hidden flex items-center gap-1 px-2 py-1.5 overflow-x-auto scrollbar-none border-t border-white/[0.06] shrink-0"
+      style={{ background: "#0b0b12" }}
+    >
+      {KEYS.map((k) => (
+        <button
+          key={k.label}
+          type="button"
+          aria-label={k.title}
+          title={k.title}
+          onMouseDown={(e) => e.preventDefault()} // keep composer focus / keyboard up
+          onClick={() => onKey(k.seq)}
+          className={`flex-shrink-0 min-w-[40px] px-2.5 py-1.5 rounded-md text-[14px] font-mono leading-none active:scale-90 transition-all select-none border ${
+            k.danger
+              ? "text-red-300/80 border-red-300/25 hover:bg-red-300/10"
+              : k.accent
+              ? "text-emerald-300/90 border-emerald-300/30 bg-emerald-300/[0.06] hover:bg-emerald-300/15"
+              : "text-white/70 border-white/10 hover:bg-white/[0.08]"
+          }`}
+        >
+          {k.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -1,5 +1,6 @@
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useRef, useState, useCallback } from "react";
 import type { AgentState } from "../lib/types";
+import type { XTerminalHandle } from "./XTerminal";
 
 const XTerminal = lazy(() => import("./XTerminal").then(m => ({ default: m.XTerminal })));
 
@@ -23,6 +24,46 @@ const STATUS_DOT: Record<string, string> = {
 };
 
 export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSibling, siblings }: TerminalModalProps) {
+  const xtermRef = useRef<XTerminalHandle>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [toast, setToast] = useState<{ msg: string; kind: "ok" | "warn" | "err" } | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = useCallback((msg: string, kind: "ok" | "warn" | "err" = "ok") => {
+    setToast({ msg, kind });
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 3500);
+  }, []);
+
+  // 📎 attach: upload an image to labubu-upload, then inject its saved path into
+  // the running Oracle PTY (same path-injection contract as TerminalView, but
+  // delivered through xterm's PTY socket instead of the capture-stream queue).
+  // The modal only opens for a tracked agent (claude pane), so the target is
+  // always a valid Oracle — no isClaudeWindow guard needed.
+  const uploadAttachment = useCallback(async (file: File) => {
+    setUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/upload/api/file", { method: "POST", body: fd });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.success || !data?.saved?.length) {
+        const reason = data?.errors?.[0]?.reason || `HTTP ${res.status}`;
+        showToast(`อัปโหลดล้มเหลว: ${reason}`, "err");
+        return;
+      }
+      const path: string = data.saved[0].path;
+      // `\r` submits — xterm sends CR on Enter, so this types the line and runs it.
+      xtermRef.current?.inject(`[ภาพแนบ — โปรดดู: ${path}]\r`);
+      showToast(`ส่งภาพไปที่ ${agent.name} แล้ว`, "ok");
+    } catch {
+      showToast("อัปโหลดล้มเหลว (network)", "err");
+    } finally {
+      setUploading(false);
+    }
+  }, [agent.name, showToast]);
+
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0f]">
       <div className="flex flex-col h-full">
@@ -62,6 +103,26 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
           </div>
 
           <div className="ml-auto flex items-center gap-2 shrink-0">
+            {/* 📎 attach — upload an image and inject its saved path into this Oracle */}
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/png,image/jpeg,image/webp,image/gif"
+              className="hidden"
+              onChange={(e) => {
+                const f = e.target.files?.[0];
+                if (f) uploadAttachment(f);
+                e.target.value = "";  // allow re-selecting the same file
+              }}
+            />
+            <button
+              onClick={() => { if (!uploading) fileInputRef.current?.click(); }}
+              disabled={uploading}
+              className="px-2 py-0.5 rounded text-[12px] font-mono text-white/40 hover:text-white/80 hover:bg-white/[0.06] border border-transparent hover:border-white/10 transition-all cursor-pointer disabled:cursor-not-allowed"
+              title={`แนบภาพไปยัง ${agent.name}`}
+            >
+              {uploading ? "⏳" : "📎"}
+            </button>
             <button
               onClick={() => { if (confirm(`Restart ${agent.name}?`)) send({ type: "restart", target: agent.target }); }}
               className="px-2 py-0.5 rounded text-[10px] font-mono text-white/30 hover:text-orange-400 hover:bg-orange-400/10 border border-transparent hover:border-orange-400/20 transition-all cursor-pointer"
@@ -86,6 +147,7 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
             </div>
           }>
             <XTerminal
+              ref={xtermRef}
               target={agent.target}
               onClose={onClose}
               onNavigate={onNavigate}
@@ -95,6 +157,20 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
           </Suspense>
         </div>
       </div>
+
+      {/* Attach toast — "sent to <agent>" / error */}
+      {toast && (
+        <div
+          className="absolute left-1/2 -translate-x-1/2 top-14 z-10 px-3 py-1.5 rounded-lg text-[12px] font-mono shadow-lg pointer-events-none"
+          style={{
+            background: toast.kind === "ok" ? "#1b3a2a" : toast.kind === "warn" ? "#3a341b" : "#3a1b1b",
+            color: toast.kind === "ok" ? "#7ee2a8" : toast.kind === "warn" ? "#e2cf7e" : "#e27e7e",
+            border: `1px solid ${toast.kind === "ok" ? "#2e6b4a" : toast.kind === "warn" ? "#6b5e2e" : "#6b2e2e"}`,
+          }}
+        >
+          {toast.kind === "ok" ? "✓ " : toast.kind === "warn" ? "⚠ " : "✕ "}{toast.msg}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -81,10 +81,19 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
   // TUI tab-completes / accepts its ghost suggestion. Accept-only — no trailing
   // \r — so it mirrors desktop Tab and does NOT auto-submit. The dashboard pane
   // had no React Tab handler at all before, so this also brings the focused
-  // Oracle pane to parity. The sm:hidden ⇥ button is the mobile trigger (no Tab
-  // key on phone keyboards).
+  // Oracle pane to parity. Used by the desktop Tab keydown below.
   const acceptSuggestion = useCallback(() => {
     send({ type: "send", target: agent.target, text: inputBuf + "\t", force: true });
+    setInputBuf("");
+  }, [inputBuf, agent.target, send]);
+
+  // Mobile ⇥ button = accept + submit in ONE tap (DIVERGES from desktop Tab by
+  // design — Boss 2026-06-04: "suggestion ขึ้นมาแล้วส่งให้ oracle ได้เลย").
+  // Forwards typed buffer + literal Tab + carriage return (\t\r) so the claude
+  // TUI accepts its ghost suggestion AND submits, since phones have no easy way
+  // to then press Enter. Desktop Tab keydown stays accept-only (\t).
+  const acceptSuggestionAndSubmit = useCallback(() => {
+    send({ type: "send", target: agent.target, text: inputBuf + "\t\r", force: true });
     setInputBuf("");
   }, [inputBuf, agent.target, send]);
 
@@ -225,16 +234,18 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
             className="flex-1 min-w-0 bg-transparent outline-none border-0 resize-none text-white/90 font-mono text-[13px] leading-[1.35] placeholder:text-white/20"
             style={{ caretColor: "#89b4fa", padding: 0, margin: 0 }}
           />
-          {/* Mobile ⇥ accept-suggestion — mirrors desktop Tab (sends typed text +
-              literal Tab to the PTY → claude TUI completes). sm:hidden = mobile
-              only; phones have no Tab key. The ghost lives in the TUI not React,
-              so it's always enabled rather than gated on a suggestion existing. */}
+          {/* Mobile ⇥ accept-suggestion — accepts the claude TUI ghost AND submits
+              in one tap (sends typed text + literal Tab + \r → TUI completes then
+              submits). DIVERGES from desktop Tab (accept-only) by Boss 2026-06-04
+              intent. sm:hidden = mobile only; phones have no Tab key. The ghost
+              lives in the TUI not React, so it's always enabled rather than gated
+              on a suggestion existing. */}
           <button
             type="button"
             className="sm:hidden flex-shrink-0 ml-2 px-2 py-0.5 rounded text-[12px] font-mono text-purple-300/90 border border-purple-300/25 hover:bg-purple-300/10 active:scale-95 transition-all"
-            title="รับคำแนะนำ (เหมือนกด Tab บนคีย์บอร์ด)"
+            title="รับคำแนะนำแล้วส่งเลย (เหมือนกด Tab แล้ว Enter)"
             onMouseDown={(e) => e.preventDefault()}  // keep textarea focus
-            onClick={acceptSuggestion}
+            onClick={acceptSuggestionAndSubmit}
           >
             ⇥ รับ
           </button>

--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -1,5 +1,6 @@
 import { lazy, Suspense, useRef, useState, useCallback } from "react";
 import type { AgentState } from "../lib/types";
+import { TerminalKeyBar } from "./TerminalKeyBar";
 
 const XTerminal = lazy(() => import("./XTerminal").then(m => ({ default: m.XTerminal })));
 
@@ -210,6 +211,14 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
             />
           </Suspense>
         </div>
+
+        {/* Mobile control-key bar — tap ↑↓←→ Enter Tab Esc Space Ctrl-C to drive
+            interactive claude TUIs (multi-selects) that the soft keyboard can't.
+            Routes raw key sequences through the SAME `send` PTY path as the
+            composer; server `sendKeys` maps them to tmux key names. */}
+        <TerminalKeyBar
+          onKey={(seq) => send({ type: "send", target: agent.target, text: seq, force: true })}
+        />
 
         {/* Input line — real focusable textarea so the mobile soft keyboard
             opens on the dashboard pane (xterm.js alone never raises it). Mirrors

--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -75,6 +75,19 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
   // `send` command TerminalView uses ({type:"send", force:true}) — the xterm PTY
   // attach socket drops injected input on grouped sessions, which cleared the
   // field without delivering. The server-side `send` handler submits the line.
+  // Accept-suggestion = the same accept-completion as desktop Tab in
+  // TerminalView: forward the typed buffer + a literal Tab to the PTY (via the
+  // shared `send` path that actually reaches this grouped session) so the claude
+  // TUI tab-completes / accepts its ghost suggestion. Accept-only — no trailing
+  // \r — so it mirrors desktop Tab and does NOT auto-submit. The dashboard pane
+  // had no React Tab handler at all before, so this also brings the focused
+  // Oracle pane to parity. The sm:hidden ⇥ button is the mobile trigger (no Tab
+  // key on phone keyboards).
+  const acceptSuggestion = useCallback(() => {
+    send({ type: "send", target: agent.target, text: inputBuf + "\t", force: true });
+    setInputBuf("");
+  }, [inputBuf, agent.target, send]);
+
   const handleInputKeyDown = useCallback((e: React.KeyboardEvent) => {
     // IME composition in progress (Thai/CJK) — let the keystroke commit text,
     // never treat Enter as "send" mid-composition. (Identical to TerminalView's
@@ -88,8 +101,14 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
         send({ type: "send", target: agent.target, text: inputBuf, force: true });
         setInputBuf("");
       }
+    } else if (e.key === "Tab") {
+      // Mirror TerminalView's desktop Tab: forward typed text + a literal Tab so
+      // the claude TUI tab-completes / accepts its ghost suggestion. Accept-only
+      // (no \r) — matches desktop, does NOT auto-submit.
+      e.preventDefault();
+      acceptSuggestion();
     }
-  }, [inputBuf, agent.target, send]);
+  }, [inputBuf, agent.target, send, acceptSuggestion]);
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0f]">
@@ -206,6 +225,19 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
             className="flex-1 min-w-0 bg-transparent outline-none border-0 resize-none text-white/90 font-mono text-[13px] leading-[1.35] placeholder:text-white/20"
             style={{ caretColor: "#89b4fa", padding: 0, margin: 0 }}
           />
+          {/* Mobile ⇥ accept-suggestion — mirrors desktop Tab (sends typed text +
+              literal Tab to the PTY → claude TUI completes). sm:hidden = mobile
+              only; phones have no Tab key. The ghost lives in the TUI not React,
+              so it's always enabled rather than gated on a suggestion existing. */}
+          <button
+            type="button"
+            className="sm:hidden flex-shrink-0 ml-2 px-2 py-0.5 rounded text-[12px] font-mono text-purple-300/90 border border-purple-300/25 hover:bg-purple-300/10 active:scale-95 transition-all"
+            title="รับคำแนะนำ (เหมือนกด Tab บนคีย์บอร์ด)"
+            onMouseDown={(e) => e.preventDefault()}  // keep textarea focus
+            onClick={acceptSuggestion}
+          >
+            ⇥ รับ
+          </button>
           {inputBuf && (
             <span
               className="ml-auto text-white/30 text-[11px] cursor-pointer hover:text-red-400 px-2 rounded"

--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -46,7 +46,7 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
     try {
       const fd = new FormData();
       fd.append("file", file);
-      const res = await fetch("/upload/api/file", { method: "POST", body: fd });
+      const res = await fetch("/upload/api/file", { method: "POST", credentials: "same-origin", body: fd });
       const data = await res.json().catch(() => null);
       if (!res.ok || !data?.success || !data?.saved?.length) {
         const reason = data?.errors?.[0]?.reason || `HTTP ${res.status}`;

--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -26,6 +26,8 @@ const STATUS_DOT: Record<string, string> = {
 export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSibling, siblings }: TerminalModalProps) {
   const xtermRef = useRef<XTerminalHandle>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputElRef = useRef<HTMLTextAreaElement>(null);
+  const [inputBuf, setInputBuf] = useState("");
   const [uploading, setUploading] = useState(false);
   const [toast, setToast] = useState<{ msg: string; kind: "ok" | "warn" | "err" } | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -63,6 +65,26 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
       setUploading(false);
     }
   }, [agent.name, showToast]);
+
+  // Mobile-reachable composer. The dashboard pane embeds raw xterm.js, whose
+  // internal helper-textarea never raises the soft keyboard on phones — so
+  // typing was impossible here even after TerminalView (#terminal) got its own
+  // real textarea. A real <textarea> raises the keyboard and gives native Thai
+  // IME + paste for free; we submit the line through the SAME PTY inject path
+  // the 📎 attach uses (`\r` = xterm sends CR on Enter, runs the line).
+  const handleInputKeyDown = useCallback((e: React.KeyboardEvent) => {
+    // IME composition in progress (Thai/CJK) — let the keystroke commit text,
+    // never treat Enter as "send" mid-composition.
+    if (e.nativeEvent.isComposing) return;
+    if (e.key === "Enter" && !e.shiftKey) {
+      // Enter → send; Shift+Enter falls through to native newline insertion.
+      e.preventDefault();
+      if (inputBuf) {
+        xtermRef.current?.inject(inputBuf + "\r");
+        setInputBuf("");
+      }
+    }
+  }, [inputBuf]);
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0f]">
@@ -155,6 +177,39 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
               onSelectSibling={onSelectSibling}
             />
           </Suspense>
+        </div>
+
+        {/* Input line — real focusable textarea so the mobile soft keyboard
+            opens on the dashboard pane (xterm.js alone never raises it). Mirrors
+            TerminalView's composer but routes through the PTY inject path. */}
+        <div
+          className="flex items-start px-3 py-1.5 border-t border-white/[0.06] font-mono text-[13px] min-h-[36px] shrink-0"
+          style={{ background: "#0d0d14" }}
+        >
+          <span className="text-white/30 mr-2 mt-[1px] flex-shrink-0">&gt;</span>
+          <textarea
+            ref={inputElRef}
+            value={inputBuf}
+            rows={1}
+            onChange={(e) => setInputBuf(e.target.value)}
+            onKeyDown={handleInputKeyDown}
+            placeholder={`พิมพ์ถึง ${cleanName(agent.name)}… (Enter ส่ง, Shift+Enter ขึ้นบรรทัด)`}
+            autoCapitalize="off"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
+            enterKeyHint="send"
+            className="flex-1 min-w-0 bg-transparent outline-none border-0 resize-none text-white/90 font-mono text-[13px] leading-[1.35] placeholder:text-white/20"
+            style={{ caretColor: "#89b4fa", padding: 0, margin: 0 }}
+          />
+          {inputBuf && (
+            <span
+              className="ml-auto text-white/30 text-[11px] cursor-pointer hover:text-red-400 px-2 rounded"
+              onClick={() => setInputBuf("")}
+            >
+              esc
+            </span>
+          )}
         </div>
       </div>
 

--- a/src/components/TerminalModal.tsx
+++ b/src/components/TerminalModal.tsx
@@ -1,6 +1,5 @@
 import { lazy, Suspense, useRef, useState, useCallback } from "react";
 import type { AgentState } from "../lib/types";
-import type { XTerminalHandle } from "./XTerminal";
 
 const XTerminal = lazy(() => import("./XTerminal").then(m => ({ default: m.XTerminal })));
 
@@ -24,7 +23,6 @@ const STATUS_DOT: Record<string, string> = {
 };
 
 export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSibling, siblings }: TerminalModalProps) {
-  const xtermRef = useRef<XTerminalHandle>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const inputElRef = useRef<HTMLTextAreaElement>(null);
   const [inputBuf, setInputBuf] = useState("");
@@ -38,11 +36,15 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
     toastTimer.current = setTimeout(() => setToast(null), 3500);
   }, []);
 
-  // 📎 attach: upload an image to labubu-upload, then inject its saved path into
-  // the running Oracle PTY (same path-injection contract as TerminalView, but
-  // delivered through xterm's PTY socket instead of the capture-stream queue).
-  // The modal only opens for a tracked agent (claude pane), so the target is
-  // always a valid Oracle — no isClaudeWindow guard needed.
+  // 📎 attach: upload an image to labubu-upload, then deliver its saved path to
+  // the running Oracle session. Routes through the SAME shared-dashboard-WS
+  // `send` command TerminalView uses ({type:"send", force:true}) — NOT the xterm
+  // PTY attach socket. The dashboard pane is a *grouped* tmux session whose PTY
+  // attach is display-oriented: the server streams output but drops injected
+  // input (same reason it ignores resize on grouped sessions), so xterm.inject()
+  // clears the field without ever reaching the session. Trailing `\n` submits,
+  // mirroring TerminalView's attach. The modal only opens for a tracked agent
+  // (claude pane), so the target is always a valid Oracle — no guard needed.
   const uploadAttachment = useCallback(async (file: File) => {
     setUploading(true);
     try {
@@ -56,35 +58,38 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
         return;
       }
       const path: string = data.saved[0].path;
-      // `\r` submits — xterm sends CR on Enter, so this types the line and runs it.
-      xtermRef.current?.inject(`[ภาพแนบ — โปรดดู: ${path}]\r`);
+      send({ type: "send", target: agent.target, text: `[ภาพแนบ — โปรดดู: ${path}]\n`, force: true });
       showToast(`ส่งภาพไปที่ ${agent.name} แล้ว`, "ok");
     } catch {
       showToast("อัปโหลดล้มเหลว (network)", "err");
     } finally {
       setUploading(false);
     }
-  }, [agent.name, showToast]);
+  }, [agent.name, agent.target, send, showToast]);
 
   // Mobile-reachable composer. The dashboard pane embeds raw xterm.js, whose
   // internal helper-textarea never raises the soft keyboard on phones — so
   // typing was impossible here even after TerminalView (#terminal) got its own
   // real textarea. A real <textarea> raises the keyboard and gives native Thai
-  // IME + paste for free; we submit the line through the SAME PTY inject path
-  // the 📎 attach uses (`\r` = xterm sends CR on Enter, runs the line).
+  // IME + paste for free; we deliver the line through the SAME shared-dashboard
+  // `send` command TerminalView uses ({type:"send", force:true}) — the xterm PTY
+  // attach socket drops injected input on grouped sessions, which cleared the
+  // field without delivering. The server-side `send` handler submits the line.
   const handleInputKeyDown = useCallback((e: React.KeyboardEvent) => {
     // IME composition in progress (Thai/CJK) — let the keystroke commit text,
-    // never treat Enter as "send" mid-composition.
+    // never treat Enter as "send" mid-composition. (Identical to TerminalView's
+    // working composer; Boss's clear-without-send symptom is the dropped PTY
+    // input path above, not this guard — text clears only when Enter passes it.)
     if (e.nativeEvent.isComposing) return;
     if (e.key === "Enter" && !e.shiftKey) {
       // Enter → send; Shift+Enter falls through to native newline insertion.
       e.preventDefault();
       if (inputBuf) {
-        xtermRef.current?.inject(inputBuf + "\r");
+        send({ type: "send", target: agent.target, text: inputBuf, force: true });
         setInputBuf("");
       }
     }
-  }, [inputBuf]);
+  }, [inputBuf, agent.target, send]);
 
   return (
     <div className="fixed inset-0 z-50 flex flex-col bg-[#0a0a0f]">
@@ -169,7 +174,6 @@ export function TerminalModal({ agent, send, onClose, onNavigate, onSelectSiblin
             </div>
           }>
             <XTerminal
-              ref={xtermRef}
               target={agent.target}
               onClose={onClose}
               onNavigate={onNavigate}

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -1,7 +1,7 @@
 import { memo, useState, useEffect, useRef, useCallback } from "react";
 import { ansiToHtml } from "../lib/ansi";
 import { roomStyle } from "../lib/constants";
-import { wsUrl } from "../lib/api";
+import { useWebSocket } from "../hooks/useWebSocket";
 import type { Session, AgentState } from "../lib/types";
 
 interface TerminalViewProps {
@@ -16,53 +16,42 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
   const [captureHtml, setCaptureHtml] = useState("");
   const [inputBuf, setInputBuf] = useState("");
   const [sendQueue, setSendQueue] = useState<string[]>([]);
-  const wsRef = useRef<WebSocket | null>(null);
   const outputRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<HTMLDivElement>(null);
   const sendingRef = useRef(false);
+  const selectedTargetRef = useRef<string | null>(null);
+  selectedTargetRef.current = selectedTarget;
 
-  // Own WebSocket for capture stream (separate from main fleet WS)
-  useEffect(() => {
-    const ws = new WebSocket(wsUrl("/ws"));
-    wsRef.current = ws;
-
-    ws.onmessage = (e) => {
-      try {
-        const data = JSON.parse(e.data);
-        if (data.type === "capture") {
-          const out = outputRef.current;
-          const atBottom = out ? out.scrollHeight - out.scrollTop - out.clientHeight < 60 : true;
-          setCaptureHtml(ansiToHtml(data.content || "(empty)"));
-          if (atBottom) requestAnimationFrame(() => out?.scrollTo(0, out.scrollHeight));
-        }
-      } catch {}
-    };
-
-    ws.onclose = () => { wsRef.current = null; };
-    ws.onerror = () => ws.close();
-
-    return () => { ws.close(); wsRef.current = null; };
+  // Shared WebSocket with reconnection for capture stream
+  const handleCapture = useCallback((data: any) => {
+    if (data.type === "capture") {
+      const out = outputRef.current;
+      const atBottom = out ? out.scrollHeight - out.scrollTop - out.clientHeight < 60 : true;
+      setCaptureHtml(ansiToHtml(data.content || "(empty)"));
+      if (atBottom) requestAnimationFrame(() => out?.scrollTo(0, out.scrollHeight));
+    }
   }, []);
+
+  const handleConnect = useCallback((sendFn: (msg: object) => void) => {
+    const target = selectedTargetRef.current;
+    if (target) {
+      sendFn({ type: "subscribe", target });
+      sendFn({ type: "select", target });
+    }
+  }, []);
+
+  const { send: wsSend } = useWebSocket(handleCapture, {
+    types: ["capture"],
+    onConnect: handleConnect,
+  });
 
   // Subscribe when target changes
   useEffect(() => {
-    const ws = wsRef.current;
-    if (ws?.readyState === WebSocket.OPEN && selectedTarget) {
-      ws.send(JSON.stringify({ type: "subscribe", target: selectedTarget }));
-      ws.send(JSON.stringify({ type: "select", target: selectedTarget }));
+    if (selectedTarget) {
+      wsSend({ type: "subscribe", target: selectedTarget });
+      wsSend({ type: "select", target: selectedTarget });
     }
-  }, [selectedTarget]);
-
-  // Re-subscribe when WS reconnects
-  useEffect(() => {
-    const ws = wsRef.current;
-    if (!ws) return;
-    const handler = () => {
-      if (selectedTarget) ws.send(JSON.stringify({ type: "subscribe", target: selectedTarget }));
-    };
-    ws.addEventListener("open", handler);
-    return () => ws.removeEventListener("open", handler);
-  }, [selectedTarget]);
+  }, [selectedTarget, wsSend]);
 
   const selectWindow = useCallback((target: string) => {
     setSelectedTarget(target);
@@ -75,17 +64,16 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
   // Flush send queue
   useEffect(() => {
     if (sendingRef.current || sendQueue.length === 0) return;
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN || !selectedTarget) return;
+    if (!selectedTarget) return;
 
     sendingRef.current = true;
     const text = sendQueue[0];
-    ws.send(JSON.stringify({ type: "send", target: selectedTarget, text, force: true }));
+    wsSend({ type: "send", target: selectedTarget, text, force: true });
     setTimeout(() => {
       setSendQueue(q => q.slice(1));
       sendingRef.current = false;
     }, 100);
-  }, [sendQueue, selectedTarget]);
+  }, [sendQueue, selectedTarget, wsSend]);
 
   const queueSend = useCallback((text: string) => {
     if (!text || !selectedTarget) return;

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -188,9 +188,9 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
   }, [selectedTarget, inputBuf, queueSend, selectWindow, sessions]);
 
   return (
-    <div className="flex mx-4 sm:mx-6 mb-3 rounded-2xl overflow-hidden border border-white/[0.06]" style={{ height: "calc(100vh - 72px)" }}>
-      {/* Sidebar */}
-      <div className="w-[220px] flex-shrink-0 flex flex-col border-r border-white/[0.06] overflow-y-auto" style={{ background: "#08080e" }}>
+    <div className="flex flex-col sm:flex-row mx-4 sm:mx-6 mb-3 rounded-2xl overflow-hidden border border-white/[0.06]" style={{ height: "calc(100vh - 72px)" }}>
+      {/* Sidebar — full-width capped strip on mobile (stacks above the pane), fixed 220px column on sm+ */}
+      <div className="w-full sm:w-[220px] flex-shrink-0 flex flex-col max-h-[38vh] sm:max-h-none border-b sm:border-b-0 sm:border-r border-white/[0.06] overflow-y-auto" style={{ background: "#08080e" }}>
         {sessions.map(session => {
           const style = roomStyle(session.name);
           return (
@@ -233,7 +233,7 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
       {/* Terminal pane */}
       <div
         ref={termRef}
-        className="flex-1 flex flex-col min-w-0 outline-none relative"
+        className="flex-1 flex flex-col min-w-0 min-h-0 outline-none relative"
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -22,6 +22,7 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
   const selectedTargetRef = useRef<string | null>(null);
   selectedTargetRef.current = selectedTarget;
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const inputElRef = useRef<HTMLTextAreaElement>(null);
   const [uploading, setUploading] = useState(false);
   const [toast, setToast] = useState<{ msg: string; kind: "ok" | "warn" | "err" } | null>(null);
   const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -68,8 +69,19 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
     setCaptureHtml("");
     setInputBuf("");
     setSendQueue([]);
-    termRef.current?.focus();
+    // Focus the real text field so a hardware OR mobile soft keyboard can type.
+    inputElRef.current?.focus();
   }, []);
+
+  // Window navigation shared by Alt+Arrow (desktop) and used by the input handler.
+  const gotoAdjacent = useCallback((dir: -1 | 1) => {
+    if (!selectedTargetRef.current) return;
+    const allWindows = sessions.flatMap(s => s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name })));
+    const idx = allWindows.findIndex(w => w.target === selectedTargetRef.current);
+    if (idx < 0) return;
+    const next = allWindows[(idx + dir + allWindows.length) % allWindows.length];
+    selectWindow(next.target);
+  }, [sessions, selectWindow]);
 
   // Flush send queue
   useEffect(() => {
@@ -128,69 +140,70 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
     }
   }, [selectedTarget, selectedName, agents, queueSend, showToast]);
 
-  // Paste handler — fires on right-click paste or Ctrl+Shift+V
-  const handlePaste = useCallback((e: React.ClipboardEvent) => {
-    e.preventDefault();
-    const text = e.clipboardData.getData("text");
-    if (text) setInputBuf(b => b + text);
-  }, []);
-
-  // Keyboard handler
-  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+  // Keyboard handler for the REAL textarea. Native typing/paste/IME (Thai!) is
+  // handled by the browser via onChange — we only intercept the control keys.
+  const handleInputKeyDown = useCallback((e: React.KeyboardEvent) => {
     // Alt+Arrow to navigate between windows
     if (e.altKey && (e.key === "ArrowLeft" || e.key === "ArrowRight")) {
       e.preventDefault();
-      if (!selectedTarget) return;
-      const allWindows = sessions.flatMap(s => s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name })));
-      const idx = allWindows.findIndex(w => w.target === selectedTarget);
-      if (idx < 0) return;
-      const dir = e.key === "ArrowLeft" ? -1 : 1;
-      const next = allWindows[(idx + dir + allWindows.length) % allWindows.length];
-      selectWindow(next.target);
+      gotoAdjacent(e.key === "ArrowLeft" ? -1 : 1);
       return;
     }
 
+    // IME composition in progress (Thai/CJK) — let the keystroke commit text,
+    // never treat Enter as "send" mid-composition.
+    if (e.nativeEvent.isComposing) return;
+
     if (!selectedTarget) return;
 
-    if (e.key === "Enter") {
+    if (e.key === "Enter" && !e.shiftKey) {
+      // Enter → send; Shift+Enter falls through to native newline insertion.
       e.preventDefault();
-      if (e.shiftKey) {
-        // Shift+Enter → newline in buffer
-        setInputBuf(b => b + "\n");
-      } else {
-        // Enter → send
-        if (inputBuf) { queueSend(inputBuf); setInputBuf(""); }
-      }
-    } else if (e.key === "Backspace") {
-      e.preventDefault();
-      if (e.metaKey || e.ctrlKey) setInputBuf("");
-      else setInputBuf(b => b.slice(0, -1));
+      if (inputBuf) { queueSend(inputBuf); setInputBuf(""); }
     } else if (e.key === "Escape") {
       e.preventDefault();
       setInputBuf(""); setSendQueue([]);
-    } else if (e.key === "c" && e.ctrlKey) {
-      e.preventDefault();
-      setInputBuf(""); setSendQueue([]);
-    } else if ((e.key === "v" && e.ctrlKey) || (e.key === "v" && e.metaKey)) {
-      // Ctrl+V / Cmd+V → paste from clipboard
-      e.preventDefault();
-      navigator.clipboard.readText().then(text => {
-        if (text) setInputBuf(b => b + text);
-      }).catch(() => {});
     } else if (e.key === "Tab") {
       e.preventDefault();
       queueSend(inputBuf + "\t");
       setInputBuf("");
-    } else if (e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
-      e.preventDefault();
-      setInputBuf(b => b + e.key);
     }
-  }, [selectedTarget, inputBuf, queueSend, selectWindow, sessions]);
+    // Backspace, Ctrl/Cmd+V paste, char entry, etc. — handled natively.
+  }, [selectedTarget, inputBuf, queueSend, gotoAdjacent]);
 
   return (
     <div className="flex flex-col sm:flex-row mx-4 sm:mx-6 mb-3 rounded-2xl overflow-hidden border border-white/[0.06]" style={{ height: "calc(100vh - 72px)" }}>
-      {/* Sidebar — full-width capped strip on mobile (stacks above the pane), fixed 220px column on sm+ */}
-      <div className="w-full sm:w-[220px] flex-shrink-0 flex flex-col max-h-[38vh] sm:max-h-none border-b sm:border-b-0 sm:border-r border-white/[0.06] overflow-y-auto" style={{ background: "#08080e" }}>
+      {/* Mobile oracle picker — a native dropdown replaces the long stacked fleet
+          list on phones, freeing vertical room for the terminal + input. The
+          OS-native <select> popover is the right mobile affordance. Desktop keeps
+          the full sidebar (hidden sm:flex below). */}
+      <div className="sm:hidden flex-shrink-0 border-b border-white/[0.06] px-3 py-2" style={{ background: "#08080e" }}>
+        <select
+          className="w-full bg-transparent text-[13px] font-mono text-white/90 outline-none border border-white/[0.1] rounded-lg px-2 py-1.5"
+          value={selectedTarget ?? ""}
+          onChange={(e) => { if (e.target.value) selectWindow(e.target.value); }}
+          style={{ background: "#0d0d14" }}
+        >
+          <option value="" disabled>เลือก Oracle…</option>
+          {sessions.map(session => (
+            <optgroup key={session.name} label={session.name}>
+              {session.windows.map(w => {
+                const target = `${session.name}:${w.index}`;
+                const agent = agents.find(a => a.target === target);
+                const dot = agent?.status === "busy" ? "🟠" : agent?.status === "ready" ? "🟢" : "⚫";
+                return (
+                  <option key={target} value={target}>
+                    {dot} {w.index} {w.name}
+                  </option>
+                );
+              })}
+            </optgroup>
+          ))}
+        </select>
+      </div>
+
+      {/* Sidebar — fixed 220px column on sm+; hidden on mobile (dropdown above replaces it) */}
+      <div className="hidden sm:flex sm:w-[220px] flex-shrink-0 flex-col sm:max-h-none sm:border-r border-white/[0.06] overflow-y-auto" style={{ background: "#08080e" }}>
         {sessions.map(session => {
           const style = roomStyle(session.name);
           return (
@@ -234,10 +247,7 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
       <div
         ref={termRef}
         className="flex-1 flex flex-col min-w-0 min-h-0 outline-none relative"
-        tabIndex={0}
-        onKeyDown={handleKeyDown}
-        onPaste={handlePaste}
-        onClick={() => termRef.current?.focus()}
+        onClick={() => inputElRef.current?.focus()}
       >
         {/* Attach toast — "sent to <target>" / warn / error */}
         {toast && (
@@ -306,10 +316,24 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
             {uploading ? "⏳" : "📎"}
           </span>
           <span className="text-white/30 mr-2 mt-[1px] flex-shrink-0">&gt;</span>
-          <span className="text-white/90 whitespace-pre flex-1">{inputBuf}</span>
-          <span
-            className="inline-block w-[7px] h-[15px] ml-[1px] flex-shrink-0"
-            style={{ background: selectedTarget ? "#89b4fa" : "#333", animation: "blink 1s step-end infinite", marginTop: "2px" }}
+          {/* Real focusable field — a hidden tabIndex div never raises the mobile
+              soft keyboard, so typing was impossible on phones. A textarea does,
+              and gets native Thai IME + paste for free. */}
+          <textarea
+            ref={inputElRef}
+            value={inputBuf}
+            rows={1}
+            disabled={!selectedTarget}
+            onChange={(e) => setInputBuf(e.target.value)}
+            onKeyDown={handleInputKeyDown}
+            placeholder={selectedTarget ? "พิมพ์ข้อความ… (Enter ส่ง, Shift+Enter ขึ้นบรรทัด)" : "เลือกหน้าต่างก่อน"}
+            autoCapitalize="off"
+            autoCorrect="off"
+            autoComplete="off"
+            spellCheck={false}
+            enterKeyHint="send"
+            className="flex-1 min-w-0 bg-transparent outline-none border-0 resize-none text-white/90 font-mono text-[13px] leading-[1.35] placeholder:text-white/20 disabled:cursor-not-allowed"
+            style={{ caretColor: "#89b4fa", padding: 0, margin: 0 }}
           />
           {sendQueue.length > 0 && (
             <span className="text-white/30 text-[11px] ml-2">({sendQueue.length} queued)</span>

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -21,6 +21,16 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
   const sendingRef = useRef(false);
   const selectedTargetRef = useRef<string | null>(null);
   selectedTargetRef.current = selectedTarget;
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [toast, setToast] = useState<{ msg: string; kind: "ok" | "warn" | "err" } | null>(null);
+  const toastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const showToast = useCallback((msg: string, kind: "ok" | "warn" | "err" = "ok") => {
+    setToast({ msg, kind });
+    if (toastTimer.current) clearTimeout(toastTimer.current);
+    toastTimer.current = setTimeout(() => setToast(null), 3500);
+  }, []);
 
   // Shared WebSocket with reconnection for capture stream
   const handleCapture = useCallback((data: any) => {
@@ -79,6 +89,44 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
     if (!text || !selectedTarget) return;
     setSendQueue(q => [...q, text]);
   }, [selectedTarget]);
+
+  // Display name for the selected target (also used by the attach handler).
+  const selectedName = selectedTarget
+    ? sessions.flatMap(s => s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name }))).find(w => w.target === selectedTarget)?.name || ""
+    : "";
+
+  // 📎 attach: upload an image to labubu-upload, then inject its saved path into
+  // the SELECTED Oracle session via the same queueSend path used for typing.
+  // maw only tracks claude panes as AgentState — no agent for a target ⇒ it's a
+  // bash/non-claude window, so we warn instead of injecting (path would run as a
+  // shell command and the image would never reach an Oracle's context).
+  const uploadAttachment = useCallback(async (file: File) => {
+    if (!selectedTarget) { showToast("เลือกหน้าต่างก่อนแนบภาพ", "warn"); return; }
+    const isClaudeWindow = agents.some(a => a.target === selectedTarget);
+    if (!isClaudeWindow) {
+      showToast(`"${selectedName || selectedTarget}" ไม่ใช่ Claude session — ไม่ได้ฉีดภาพ (เลือกหน้าต่าง Oracle)`, "warn");
+      return;
+    }
+    setUploading(true);
+    try {
+      const fd = new FormData();
+      fd.append("file", file);
+      const res = await fetch("/upload/api/file", { method: "POST", body: fd });
+      const data = await res.json().catch(() => null);
+      if (!res.ok || !data?.success || !data?.saved?.length) {
+        const reason = data?.errors?.[0]?.reason || `HTTP ${res.status}`;
+        showToast(`อัปโหลดล้มเหลว: ${reason}`, "err");
+        return;
+      }
+      const path: string = data.saved[0].path;
+      queueSend(`[ภาพแนบ — โปรดดู: ${path}]\n`);
+      showToast(`ส่งภาพไปที่ ${selectedName || selectedTarget} แล้ว`, "ok");
+    } catch {
+      showToast("อัปโหลดล้มเหลว (network)", "err");
+    } finally {
+      setUploading(false);
+    }
+  }, [selectedTarget, selectedName, agents, queueSend, showToast]);
 
   // Paste handler — fires on right-click paste or Ctrl+Shift+V
   const handlePaste = useCallback((e: React.ClipboardEvent) => {
@@ -139,11 +187,6 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
     }
   }, [selectedTarget, inputBuf, queueSend, selectWindow, sessions]);
 
-  // Get display name for selected target
-  const selectedName = selectedTarget
-    ? sessions.flatMap(s => s.windows.map(w => ({ target: `${s.name}:${w.index}`, name: w.name }))).find(w => w.target === selectedTarget)?.name || ""
-    : "";
-
   return (
     <div className="flex mx-4 sm:mx-6 mb-3 rounded-2xl overflow-hidden border border-white/[0.06]" style={{ height: "calc(100vh - 72px)" }}>
       {/* Sidebar */}
@@ -190,12 +233,25 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
       {/* Terminal pane */}
       <div
         ref={termRef}
-        className="flex-1 flex flex-col min-w-0 outline-none"
+        className="flex-1 flex flex-col min-w-0 outline-none relative"
         tabIndex={0}
         onKeyDown={handleKeyDown}
         onPaste={handlePaste}
         onClick={() => termRef.current?.focus()}
       >
+        {/* Attach toast — "sent to <target>" / warn / error */}
+        {toast && (
+          <div
+            className="absolute left-1/2 -translate-x-1/2 top-3 z-10 px-3 py-1.5 rounded-lg text-[12px] font-mono shadow-lg pointer-events-none"
+            style={{
+              background: toast.kind === "ok" ? "#1b3a2a" : toast.kind === "warn" ? "#3a341b" : "#3a1b1b",
+              color: toast.kind === "ok" ? "#7ee2a8" : toast.kind === "warn" ? "#e2cf7e" : "#e27e7e",
+              border: `1px solid ${toast.kind === "ok" ? "#2e6b4a" : toast.kind === "warn" ? "#6b5e2e" : "#6b2e2e"}`,
+            }}
+          >
+            {toast.kind === "ok" ? "✓ " : toast.kind === "warn" ? "⚠ " : "✕ "}{toast.msg}
+          </div>
+        )}
         {/* Header */}
         <div className="flex items-center gap-3 px-4 py-2 border-b border-white/[0.06] flex-shrink-0" style={{ background: "#0a0a12" }}>
           <span className="text-xs font-mono text-white/40">{selectedName || "select a window"}</span>
@@ -225,6 +281,30 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
           className="flex items-start px-3 py-1.5 border-t border-white/[0.06] font-mono text-[13px] min-h-[32px]"
           style={{ background: "#0d0d14" }}
         >
+          {/* 📎 attach — target-aware: disabled until a window is selected */}
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            className="hidden"
+            onChange={(e) => {
+              const f = e.target.files?.[0];
+              if (f) uploadAttachment(f);
+              e.target.value = "";  // allow re-selecting the same file
+            }}
+          />
+          <span
+            className="mr-2 mt-[1px] flex-shrink-0 select-none"
+            title={selectedTarget ? "แนบภาพไปยังหน้าต่างที่เลือก" : "เลือกหน้าต่างก่อน"}
+            style={{
+              cursor: selectedTarget && !uploading ? "pointer" : "not-allowed",
+              opacity: selectedTarget && !uploading ? 0.85 : 0.25,
+            }}
+            onMouseDown={(e) => e.preventDefault()}  // keep terminal focus
+            onClick={() => { if (selectedTarget && !uploading) fileInputRef.current?.click(); }}
+          >
+            {uploading ? "⏳" : "📎"}
+          </span>
           <span className="text-white/30 mr-2 mt-[1px] flex-shrink-0">&gt;</span>
           <span className="text-white/90 whitespace-pre flex-1">{inputBuf}</span>
           <span

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -140,6 +140,18 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
     }
   }, [selectedTarget, selectedName, agents, queueSend, showToast]);
 
+  // Accept-suggestion = exactly what desktop Tab does: forward the typed buffer
+  // PLUS a literal Tab to the PTY, so the claude TUI running in the captured pane
+  // tab-completes / accepts its own ghost suggestion. Desktop Tab is ACCEPT-ONLY
+  // (no trailing \r) — it does NOT auto-submit; the user presses Enter after. We
+  // mirror that precisely. Mobile soft keyboards have no Tab key, so the
+  // sm:hidden ⇥ button below is the only way to trigger this on a phone.
+  const acceptSuggestion = useCallback(() => {
+    if (!selectedTarget) return;
+    queueSend(inputBuf + "\t");
+    setInputBuf("");
+  }, [selectedTarget, inputBuf, queueSend]);
+
   // Keyboard handler for the REAL textarea. Native typing/paste/IME (Thai!) is
   // handled by the browser via onChange — we only intercept the control keys.
   const handleInputKeyDown = useCallback((e: React.KeyboardEvent) => {
@@ -165,11 +177,10 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
       setInputBuf(""); setSendQueue([]);
     } else if (e.key === "Tab") {
       e.preventDefault();
-      queueSend(inputBuf + "\t");
-      setInputBuf("");
+      acceptSuggestion();
     }
     // Backspace, Ctrl/Cmd+V paste, char entry, etc. — handled natively.
-  }, [selectedTarget, inputBuf, queueSend, gotoAdjacent]);
+  }, [selectedTarget, inputBuf, queueSend, gotoAdjacent, acceptSuggestion]);
 
   return (
     <div className="flex flex-col sm:flex-row mx-4 sm:mx-6 mb-3 rounded-2xl overflow-hidden border border-white/[0.06]" style={{ height: "calc(100vh - 72px)" }}>
@@ -335,6 +346,23 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
             className="flex-1 min-w-0 bg-transparent outline-none border-0 resize-none text-white/90 font-mono text-[13px] leading-[1.35] placeholder:text-white/20 disabled:cursor-not-allowed"
             style={{ caretColor: "#89b4fa", padding: 0, margin: 0 }}
           />
+          {/* Mobile ⇥ accept-suggestion — phones have no Tab key, so this button
+              is the only way to fire the same accept-completion as desktop Tab
+              (sends typed text + literal Tab to the PTY → claude TUI completes).
+              sm:hidden = mobile-only, like the oracle dropdown above. Enabled
+              whenever a window is selected (matches when desktop Tab does
+              anything); the ghost lives in the TUI, not React, so we can't gate
+              on "a suggestion currently exists". */}
+          <button
+            type="button"
+            className="sm:hidden flex-shrink-0 ml-2 px-2 py-0.5 rounded text-[12px] font-mono text-purple-300/90 border border-purple-300/25 hover:bg-purple-300/10 active:scale-95 disabled:opacity-25 disabled:cursor-not-allowed transition-all"
+            title="รับคำแนะนำ (เหมือนกด Tab บนคีย์บอร์ด)"
+            disabled={!selectedTarget}
+            onMouseDown={(e) => e.preventDefault()}  // keep textarea focus
+            onClick={acceptSuggestion}
+          >
+            ⇥ รับ
+          </button>
           {sendQueue.length > 0 && (
             <span className="text-white/30 text-[11px] ml-2">({sendQueue.length} queued)</span>
           )}

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -111,7 +111,7 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
     try {
       const fd = new FormData();
       fd.append("file", file);
-      const res = await fetch("/upload/api/file", { method: "POST", body: fd });
+      const res = await fetch("/upload/api/file", { method: "POST", credentials: "same-origin", body: fd });
       const data = await res.json().catch(() => null);
       if (!res.ok || !data?.success || !data?.saved?.length) {
         const reason = data?.errors?.[0]?.reason || `HTTP ${res.status}`;

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -2,6 +2,7 @@ import { memo, useState, useEffect, useRef, useCallback } from "react";
 import { ansiToHtml } from "../lib/ansi";
 import { roomStyle } from "../lib/constants";
 import { useWebSocket } from "../hooks/useWebSocket";
+import { TerminalKeyBar } from "./TerminalKeyBar";
 import type { Session, AgentState } from "../lib/types";
 
 interface TerminalViewProps {
@@ -306,6 +307,13 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
             </div>
           )}
         </div>
+
+        {/* Mobile control-key bar — same raw-key PTY path as the composer, for
+            driving interactive claude TUIs the soft keyboard can't reach. Keys
+            send immediately (no queue) so arrow navigation feels responsive. */}
+        <TerminalKeyBar
+          onKey={(seq) => { if (selectedTarget) wsSend({ type: "send", target: selectedTarget, text: seq, force: true }); }}
+        />
 
         {/* Input line */}
         <div

--- a/src/components/TerminalView.tsx
+++ b/src/components/TerminalView.tsx
@@ -143,12 +143,22 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
   // Accept-suggestion = exactly what desktop Tab does: forward the typed buffer
   // PLUS a literal Tab to the PTY, so the claude TUI running in the captured pane
   // tab-completes / accepts its own ghost suggestion. Desktop Tab is ACCEPT-ONLY
-  // (no trailing \r) — it does NOT auto-submit; the user presses Enter after. We
-  // mirror that precisely. Mobile soft keyboards have no Tab key, so the
-  // sm:hidden ⇥ button below is the only way to trigger this on a phone.
+  // (no trailing \r) — it does NOT auto-submit; the user presses Enter after. The
+  // desktop Tab keydown below uses this handler and keeps that accept-only shape.
   const acceptSuggestion = useCallback(() => {
     if (!selectedTarget) return;
     queueSend(inputBuf + "\t");
+    setInputBuf("");
+  }, [selectedTarget, inputBuf, queueSend]);
+
+  // Mobile ⇥ button = accept + submit in ONE tap (DIVERGES from desktop Tab by
+  // design — Boss 2026-06-04: "suggestion ขึ้นมาแล้วส่งให้ oracle ได้เลย"). It
+  // forwards the typed buffer + a literal Tab + a carriage return (\t\r), so the
+  // claude TUI accepts its ghost suggestion AND submits the line, since phones
+  // have no convenient way to then press Enter. Desktop Tab stays accept-only.
+  const acceptSuggestionAndSubmit = useCallback(() => {
+    if (!selectedTarget) return;
+    queueSend(inputBuf + "\t\r");
     setInputBuf("");
   }, [selectedTarget, inputBuf, queueSend]);
 
@@ -347,19 +357,20 @@ export const TerminalView = memo(function TerminalView({ sessions, agents, conne
             style={{ caretColor: "#89b4fa", padding: 0, margin: 0 }}
           />
           {/* Mobile ⇥ accept-suggestion — phones have no Tab key, so this button
-              is the only way to fire the same accept-completion as desktop Tab
-              (sends typed text + literal Tab to the PTY → claude TUI completes).
-              sm:hidden = mobile-only, like the oracle dropdown above. Enabled
-              whenever a window is selected (matches when desktop Tab does
-              anything); the ghost lives in the TUI, not React, so we can't gate
-              on "a suggestion currently exists". */}
+              is the only way to accept the claude TUI's ghost suggestion on a
+              phone. Unlike desktop Tab (accept-only), this button accepts AND
+              submits in one tap (sends typed text + literal Tab + \r → TUI
+              completes then submits) — Boss 2026-06-04 intent. sm:hidden =
+              mobile-only, like the oracle dropdown above. Enabled whenever a
+              window is selected; the ghost lives in the TUI, not React, so we
+              can't gate on "a suggestion currently exists". */}
           <button
             type="button"
             className="sm:hidden flex-shrink-0 ml-2 px-2 py-0.5 rounded text-[12px] font-mono text-purple-300/90 border border-purple-300/25 hover:bg-purple-300/10 active:scale-95 disabled:opacity-25 disabled:cursor-not-allowed transition-all"
-            title="รับคำแนะนำ (เหมือนกด Tab บนคีย์บอร์ด)"
+            title="รับคำแนะนำแล้วส่งเลย (เหมือนกด Tab แล้ว Enter)"
             disabled={!selectedTarget}
             onMouseDown={(e) => e.preventDefault()}  // keep textarea focus
-            onClick={acceptSuggestion}
+            onClick={acceptSuggestionAndSubmit}
           >
             ⇥ รับ
           </button>

--- a/src/components/WorktreeView.tsx
+++ b/src/components/WorktreeView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiUrl } from "../lib/api";
+import { PageShell } from "./PageShell";
 
 interface WorktreeInfo {
   path: string;
@@ -82,7 +83,7 @@ export function WorktreeView() {
   const activeCount = worktrees.filter((wt) => wt.status === "active").length;
 
   return (
-    <div className="p-6 max-w-5xl mx-auto">
+    <PageShell>
       {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
@@ -191,6 +192,6 @@ export function WorktreeView() {
           })}
         </div>
       )}
-    </div>
+    </PageShell>
   );
 }

--- a/src/components/WorktreeView.tsx
+++ b/src/components/WorktreeView.tsx
@@ -1,6 +1,11 @@
 import { useState, useEffect, useCallback } from "react";
 import { apiUrl } from "../lib/api";
+import { cached, cacheBus } from "../lib/cache";
 import { PageShell } from "./PageShell";
+
+const WORKTREE_CACHE_KEY = "maw-ui:worktrees:v1";
+const WORKTREE_CACHE_TAG = "worktrees";
+const WORKTREE_TTL_MS = 15_000;
 
 interface WorktreeInfo {
   path: string;
@@ -30,11 +35,18 @@ export function WorktreeView() {
     setLoading(true);
     setError("");
     try {
-      const res = await fetch(apiUrl("/api/worktrees"));
-      const data = await res.json();
+      const data = await cached(
+        WORKTREE_CACHE_KEY,
+        WORKTREE_TTL_MS,
+        async () => {
+          const res = await fetch(apiUrl("/api/worktrees"));
+          return res.json();
+        },
+        { tag: WORKTREE_CACHE_TAG },
+      );
       if (Array.isArray(data)) {
         setWorktrees(data);
-      } else if (data.error) {
+      } else if (data?.error) {
         setError(data.error);
       }
     } catch (e: any) {
@@ -56,7 +68,7 @@ export function WorktreeView() {
       const data = await res.json();
       if (data.ok) {
         setLogs((prev) => ({ ...prev, [wt.path]: data.log }));
-        // Refresh after cleanup
+        cacheBus.invalidate(WORKTREE_CACHE_TAG);
         setTimeout(fetchWorktrees, 500);
       } else {
         setLogs((prev) => ({ ...prev, [wt.path]: [`Error: ${data.error}`] }));

--- a/src/components/XTerminal.tsx
+++ b/src/components/XTerminal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, forwardRef, useImperativeHandle } from "react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
@@ -13,6 +13,15 @@ interface XTerminalProps {
   onSelectSibling: (agent: AgentState) => void;
   readOnly?: boolean;
 }
+
+// Imperative handle so the chrome (TerminalModal) can inject text into the PTY
+// without owning the WebSocket — used by the 📎 attach button to type a saved
+// image path into the running Oracle, mirroring TerminalView's queueSend path.
+export interface XTerminalHandle {
+  inject: (text: string) => void;
+}
+
+const enc = new TextEncoder();
 
 // Catppuccin Mocha palette (matches AC array in ansi.ts)
 const THEME = {
@@ -39,8 +48,22 @@ const THEME = {
   brightWhite: "#ffffff",
 };
 
-export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibling, readOnly = false }: XTerminalProps) {
+export const XTerminal = forwardRef<XTerminalHandle, XTerminalProps>(function XTerminal(
+  { target, onClose, onNavigate, siblings, onSelectSibling, readOnly = false },
+  ref,
+) {
   const containerRef = useRef<HTMLDivElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  // Inject text into the live PTY as if typed. `\r` submits (xterm sends CR on
+  // Enter). No-op in read-only mode or when the socket isn't open.
+  useImperativeHandle(ref, () => ({
+    inject: (text: string) => {
+      const ws = wsRef.current;
+      if (readOnly || !ws || ws.readyState !== WebSocket.OPEN) return;
+      ws.send(enc.encode(text));
+    },
+  }), [readOnly]);
 
   // Keep callbacks in refs so terminal effect doesn't re-run on every render
   const onCloseRef = useRef(onClose);
@@ -86,6 +109,7 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
       // Connect to PTY WebSocket
       ws = new WebSocket(wsUrl("/ws/pty"));
       ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
 
       ws.onopen = () => {
         ws!.send(JSON.stringify({
@@ -172,9 +196,10 @@ export function XTerminal({ target, onClose, onNavigate, siblings, onSelectSibli
       dataSub?.dispose();
       binSub?.dispose();
       ws?.close();
+      if (wsRef.current === ws) wsRef.current = null;
       term.dispose();
     };
   }, [target]);
 
   return <div ref={containerRef} className="w-full h-full" />;
-}
+});

--- a/src/components/chat/OracleStatus.tsx
+++ b/src/components/chat/OracleStatus.tsx
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+import { apiUrl } from "../../lib/api";
+
+const STATUS_COLORS: Record<string, string> = {
+  busy: "#4caf50",
+  ready: "#fbbf24",
+  idle: "#64748b",
+  offline: "#ef4444",
+};
+
+export function OracleStatus({ oracle }: { oracle: string }) {
+  const [status, setStatus] = useState<string>("...");
+
+  useEffect(() => {
+    let alive = true;
+    const poll = () => {
+      fetch(apiUrl(`/api/dispatch/status/${encodeURIComponent(oracle)}`))
+        .then(r => r.json())
+        .then(d => { if (alive) setStatus(d.status || "offline"); })
+        .catch(() => { if (alive) setStatus("offline"); });
+    };
+    poll();
+    const iv = setInterval(poll, 10_000);
+    return () => { alive = false; clearInterval(iv); };
+  }, [oracle]);
+
+  const color = STATUS_COLORS[status] || "#64748b";
+
+  return (
+    <span className="inline-flex items-center gap-1" title={`${oracle}: ${status}`}>
+      <span
+        className="w-2 h-2 rounded-full flex-shrink-0"
+        style={{
+          background: color,
+          boxShadow: status === "busy" ? `0 0 6px ${color}` : "none",
+          animation: status === "busy" ? "agent-pulse 1.5s ease-in-out infinite" : "none",
+        }}
+      />
+      <span className="text-[9px] font-mono" style={{ color: `${color}99` }}>{status}</span>
+    </span>
+  );
+}

--- a/src/components/chat/useChatLog.ts
+++ b/src/components/chat/useChatLog.ts
@@ -14,10 +14,13 @@ export function useChatLog(mode: string) {
   // Initial fetch
   useEffect(() => {
     setLoading(true);
-    fetch(apiUrl("/api/maw-log?limit=500"))
+    fetch(apiUrl("/api/chats?limit=500"))
       .then((r) => r.json())
       .then((data) => {
-        setEntries((data.entries || []).filter((e: MawLogEntry) => e.from && e.to));
+        const mapped: MawLogEntry[] = (data.entries || [])
+          .filter((e: any) => e.from && e.to)
+          .map((e: any) => ({ ts: e.ts, from: e.from, to: e.to, msg: e.msg, ch: e.threadId }));
+        setEntries(mapped);
         setTotal(data.total || 0);
         setLoading(false);
       })

--- a/src/components/chat/useChatLog.ts
+++ b/src/components/chat/useChatLog.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { type MawLogEntry, formatDate, pairKey } from "./types";
 import { apiUrl } from "../../lib/api";
+import { cached } from "../../lib/cache";
 import { useWebSocket } from "../../hooks/useWebSocket";
 
 export function useChatLog(mode: string) {
@@ -14,9 +15,13 @@ export function useChatLog(mode: string) {
   // Initial fetch
   useEffect(() => {
     setLoading(true);
-    fetch(apiUrl("/api/chats?limit=500"))
-      .then((r) => r.json())
-      .then((data) => {
+    cached(
+      "chats-500",
+      60_000,
+      () => fetch(apiUrl("/api/chats?limit=500")).then((r) => r.json()),
+      { tag: "chats" },
+    )
+      .then((data: any) => {
         const mapped: MawLogEntry[] = (data.entries || [])
           .filter((e: any) => e.from && e.to)
           .map((e: any) => ({ ts: e.ts, from: e.from, to: e.to, msg: e.msg, ch: e.threadId }));

--- a/src/components/chat/useChatLog.ts
+++ b/src/components/chat/useChatLog.ts
@@ -1,12 +1,15 @@
-import { useState, useEffect, useMemo, useRef } from "react";
+import { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { type MawLogEntry, formatDate, pairKey } from "./types";
-import { apiUrl, wsUrl } from "../../lib/api";
+import { apiUrl } from "../../lib/api";
+import { useWebSocket } from "../../hooks/useWebSocket";
 
 export function useChatLog(mode: string) {
   const [entries, setEntries] = useState<MawLogEntry[]>([]);
   const [total, setTotal] = useState(0);
   const [loading, setLoading] = useState(true);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
 
   // Initial fetch
   useEffect(() => {
@@ -21,29 +24,20 @@ export function useChatLog(mode: string) {
       .catch(() => setLoading(false));
   }, []);
 
-  // Real-time: listen for WebSocket push of new maw-log entries
-  useEffect(() => {
-    const url = wsUrl("/ws");
-    let ws: WebSocket | null = null;
-    try {
-      ws = new WebSocket(url);
-      ws.onmessage = (ev) => {
-        try {
-          const msg = JSON.parse(ev.data);
-          if (msg.type === "maw-log" && msg.entries) {
-            setEntries(prev => [...prev, ...msg.entries]);
-            setTotal(prev => prev + msg.entries.length);
-            if (mode === "live") {
-              requestAnimationFrame(() => {
-                scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
-              });
-            }
-          }
-        } catch {}
-      };
-    } catch {}
-    return () => { ws?.close(); };
-  }, [mode]);
+  // Real-time: shared WebSocket with reconnection
+  const handleMessage = useCallback((msg: any) => {
+    if (msg.type === "maw-log" && msg.entries) {
+      setEntries(prev => [...prev, ...msg.entries]);
+      setTotal(prev => prev + msg.entries.length);
+      if (modeRef.current === "live") {
+        requestAnimationFrame(() => {
+          scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight, behavior: "smooth" });
+        });
+      }
+    }
+  }, []);
+
+  useWebSocket(handleMessage, { types: ["maw-log"] });
 
   return { entries, total, loading, scrollRef };
 }

--- a/src/hooks/useSessions.ts
+++ b/src/hooks/useSessions.ts
@@ -152,12 +152,12 @@ export function useSessions() {
     const oracleName = agent?.name || event.oracle;
 
     // Capture Stop message — this has the actual question text
-    if (event.event === "Stop" && event.message.trim()) {
+    if (event.event === "Stop" && event.message?.trim()) {
       lastStopMessage.current[oracleName] = event.message.trim();
     }
 
     if (event.event === "Notification") {
-      const msg = event.message.toLowerCase();
+      const msg = (event.message ?? "").toLowerCase();
       let askType: AskType | null = null;
       if (msg.includes("waiting for your input") || msg.includes("waiting for input")) askType = "input";
       else if (msg.includes("needs your attention") || msg.includes("attention")) askType = "attention";
@@ -168,7 +168,7 @@ export function useSessions() {
         if (!stopMsg) {
           for (let i = feedEventsRef.current.length - 1; i >= 0; i--) {
             const fe = feedEventsRef.current[i];
-            if (fe.oracle === event.oracle && fe.event === "Stop" && fe.message.trim()) {
+            if (fe.oracle === event.oracle && fe.event === "Stop" && fe.message?.trim()) {
               stopMsg = fe.message.trim();
               break;
             }

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -6,30 +6,59 @@ type MessageHandler = (data: any) => void;
 const BASE_DELAY = 1000;
 const MAX_DELAY = 30000;
 
-export function useWebSocket(onMessage: MessageHandler) {
+interface UseWebSocketOptions {
+  /** WebSocket path (default: "/ws") */
+  path?: string;
+  /** Only call onMessage for these message types (if set) */
+  types?: string[];
+  /** Called on each (re)connect — use to re-subscribe */
+  onConnect?: (send: (msg: object) => void) => void;
+}
+
+/**
+ * Shared WebSocket hook with exponential backoff reconnection.
+ * All views should use this instead of creating raw WebSocket connections.
+ */
+export function useWebSocket(onMessage: MessageHandler, options?: UseWebSocketOptions) {
   const wsRef = useRef<WebSocket | null>(null);
   const [connected, setConnected] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
+  const optionsRef = useRef(options);
+  optionsRef.current = options;
 
   useEffect(() => {
     let alive = true;
     let reconnectTimer: ReturnType<typeof setTimeout>;
     let attempt = 0;
 
+    const sendFn = (msg: object) => {
+      const ws = wsRef.current;
+      if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify(msg));
+      }
+    };
+
     function connect() {
       if (!alive) return;
-      const ws = new WebSocket(wsUrl("/ws"));
+      const path = optionsRef.current?.path || "/ws";
+      const ws = new WebSocket(wsUrl(path));
       wsRef.current = ws;
 
       ws.onopen = () => {
         attempt = 0;
         setConnected(true);
         setReconnecting(false);
+        optionsRef.current?.onConnect?.(sendFn);
       };
       ws.onmessage = (e) => {
-        try { onMessageRef.current(JSON.parse(e.data)); } catch {}
+        try {
+          const data = JSON.parse(e.data);
+          const types = optionsRef.current?.types;
+          if (types && !types.includes(data.type)) return;
+          onMessageRef.current(data);
+        } catch {}
       };
       ws.onclose = () => {
         setConnected(false);

--- a/src/hooks/useWebSocket.ts
+++ b/src/hooks/useWebSocket.ts
@@ -15,77 +15,184 @@ interface UseWebSocketOptions {
   onConnect?: (send: (msg: object) => void) => void;
 }
 
+// ─── Singleton WebSocket manager ───────────────────────────────────
+// All useWebSocket() calls share a single connection per path.
+// Subscribers register callbacks; the manager fans out messages.
+
+interface Subscriber {
+  id: number;
+  handler: MessageHandler;
+  types?: string[];
+  onConnect?: (send: (msg: object) => void) => void;
+}
+
+interface WsManager {
+  ws: WebSocket | null;
+  subscribers: Subscriber[];
+  connected: boolean;
+  reconnecting: boolean;
+  alive: boolean;
+  attempt: number;
+  reconnectTimer: ReturnType<typeof setTimeout> | undefined;
+  listeners: Set<() => void>;
+}
+
+const managers = new Map<string, WsManager>();
+let nextSubId = 1;
+
+function getManager(path: string): WsManager {
+  let mgr = managers.get(path);
+  if (!mgr) {
+    mgr = {
+      ws: null,
+      subscribers: [],
+      connected: false,
+      reconnecting: false,
+      alive: false,
+      attempt: 0,
+      reconnectTimer: undefined,
+      listeners: new Set(),
+    };
+    managers.set(path, mgr);
+  }
+  return mgr;
+}
+
+function notifyListeners(mgr: WsManager) {
+  for (const fn of mgr.listeners) fn();
+}
+
+function sendViaManager(mgr: WsManager, msg: object) {
+  const ws = mgr.ws;
+  if (ws && ws.readyState === WebSocket.OPEN) {
+    ws.send(JSON.stringify(msg));
+  }
+}
+
+function ensureConnection(mgr: WsManager, path: string) {
+  if (mgr.alive) return; // already running
+  mgr.alive = true;
+  mgr.attempt = 0;
+
+  function connect() {
+    if (!mgr.alive) return;
+    const ws = new WebSocket(wsUrl(path));
+    mgr.ws = ws;
+
+    ws.onopen = () => {
+      mgr.attempt = 0;
+      mgr.connected = true;
+      mgr.reconnecting = false;
+      notifyListeners(mgr);
+      // Notify all subscribers' onConnect callbacks
+      const sendFn = (msg: object) => sendViaManager(mgr, msg);
+      for (const sub of mgr.subscribers) {
+        sub.onConnect?.(sendFn);
+      }
+    };
+
+    ws.onmessage = (e) => {
+      try {
+        const data = JSON.parse(e.data);
+        for (const sub of mgr.subscribers) {
+          if (sub.types && !sub.types.includes(data.type)) continue;
+          sub.handler(data);
+        }
+      } catch {}
+    };
+
+    ws.onclose = () => {
+      mgr.connected = false;
+      if (mgr.alive) {
+        mgr.reconnecting = true;
+        notifyListeners(mgr);
+        const delay = Math.min(BASE_DELAY * 2 ** mgr.attempt, MAX_DELAY);
+        mgr.attempt++;
+        mgr.reconnectTimer = setTimeout(connect, delay);
+      }
+    };
+
+    ws.onerror = () => ws.close();
+  }
+
+  connect();
+}
+
+function teardownIfEmpty(mgr: WsManager, path: string) {
+  if (mgr.subscribers.length === 0) {
+    mgr.alive = false;
+    clearTimeout(mgr.reconnectTimer);
+    mgr.ws?.close();
+    mgr.ws = null;
+    mgr.connected = false;
+    mgr.reconnecting = false;
+    managers.delete(path);
+  }
+}
+
 /**
- * Shared WebSocket hook with exponential backoff reconnection.
- * All views should use this instead of creating raw WebSocket connections.
+ * Shared WebSocket hook — singleton per path.
+ * All views share one connection; messages are fanned out to subscribers.
+ * Supports auto-reconnect with exponential backoff.
  */
 export function useWebSocket(onMessage: MessageHandler, options?: UseWebSocketOptions) {
-  const wsRef = useRef<WebSocket | null>(null);
-  const [connected, setConnected] = useState(false);
-  const [reconnecting, setReconnecting] = useState(false);
+  const path = options?.path || "/ws";
   const onMessageRef = useRef(onMessage);
   onMessageRef.current = onMessage;
   const optionsRef = useRef(options);
   optionsRef.current = options;
+  const subIdRef = useRef<number>(0);
+
+  const [connected, setConnected] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
 
   useEffect(() => {
-    let alive = true;
-    let reconnectTimer: ReturnType<typeof setTimeout>;
-    let attempt = 0;
+    const mgr = getManager(path);
+    const id = nextSubId++;
+    subIdRef.current = id;
 
-    const sendFn = (msg: object) => {
-      const ws = wsRef.current;
-      if (ws && ws.readyState === WebSocket.OPEN) {
-        ws.send(JSON.stringify(msg));
-      }
+    const sub: Subscriber = {
+      id,
+      handler: (data: any) => onMessageRef.current(data),
+      types: optionsRef.current?.types,
+      onConnect: optionsRef.current?.onConnect,
     };
 
-    function connect() {
-      if (!alive) return;
-      const path = optionsRef.current?.path || "/ws";
-      const ws = new WebSocket(wsUrl(path));
-      wsRef.current = ws;
+    mgr.subscribers.push(sub);
 
-      ws.onopen = () => {
-        attempt = 0;
-        setConnected(true);
-        setReconnecting(false);
-        optionsRef.current?.onConnect?.(sendFn);
-      };
-      ws.onmessage = (e) => {
-        try {
-          const data = JSON.parse(e.data);
-          const types = optionsRef.current?.types;
-          if (types && !types.includes(data.type)) return;
-          onMessageRef.current(data);
-        } catch {}
-      };
-      ws.onclose = () => {
-        setConnected(false);
-        if (alive) {
-          setReconnecting(true);
-          const delay = Math.min(BASE_DELAY * 2 ** attempt, MAX_DELAY);
-          attempt++;
-          reconnectTimer = setTimeout(connect, delay);
-        }
-      };
-      ws.onerror = () => ws.close();
+    // Sync initial state
+    setConnected(mgr.connected);
+    setReconnecting(mgr.reconnecting);
+
+    // Listen for state changes
+    const listener = () => {
+      setConnected(mgr.connected);
+      setReconnecting(mgr.reconnecting);
+    };
+    mgr.listeners.add(listener);
+
+    // Start connection if not already running
+    ensureConnection(mgr, path);
+
+    // If already connected, fire onConnect immediately
+    if (mgr.connected && sub.onConnect) {
+      sub.onConnect((msg) => sendViaManager(mgr, msg));
     }
 
-    connect();
     return () => {
-      alive = false;
-      clearTimeout(reconnectTimer);
-      wsRef.current?.close();
+      mgr.listeners.delete(listener);
+      mgr.subscribers = mgr.subscribers.filter((s) => s.id !== id);
+      teardownIfEmpty(mgr, path);
     };
-  }, []);
+  }, [path]);
 
-  const send = useCallback((msg: object) => {
-    const ws = wsRef.current;
-    if (ws && ws.readyState === WebSocket.OPEN) {
-      ws.send(JSON.stringify(msg));
-    }
-  }, []);
+  const send = useCallback(
+    (msg: object) => {
+      const mgr = managers.get(path);
+      if (mgr) sendViaManager(mgr, msg);
+    },
+    [path],
+  );
 
   return { connected, reconnecting, send };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,9 @@
 body {
   background: #0a0a0f;
   color: #e0e0e0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Noto Sans Thai', 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+  font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  font-size: 13px;
+  line-height: 1.35;
   overflow-x: hidden;
 }
 
@@ -14,12 +16,22 @@ button, [role="button"], a[href], summary { cursor: pointer; }
 ::-webkit-scrollbar-track { background: #0a0a0f; }
 ::-webkit-scrollbar-thumb { background: #2a2a3e; border-radius: 3px; }
 
+/* Readable mono font */
+.font-mono, code, pre, [style*="monospace"] {
+  font-family: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace !important;
+  letter-spacing: 0.02em;
+}
+
+/* Readability: bump tiny text to match terminal baseline */
+[class*="text-[9px]"] { font-size: 11px !important; }
+[class*="text-[10px]"] { font-size: 12px !important; }
+
 /* Mobile optimizations */
 @media (max-width: 640px) {
   /* Prevent text size adjust on orientation change */
   html { -webkit-text-size-adjust: 100%; }
-  /* Smaller fonts for mobile */
-  .font-mono { font-size: 11px; }
+  /* Readable fonts for mobile */
+  .font-mono { font-size: 13px; }
   /* Touch-friendly tap targets — Apple HIG recommends 44px */
   button, [role="button"], select { min-height: 36px; }
   /* Fix bottom bar overlap with mobile browser chrome */

--- a/src/index.css
+++ b/src/index.css
@@ -20,13 +20,14 @@ button, [role="button"], a[href], summary { cursor: pointer; }
   html { -webkit-text-size-adjust: 100%; }
   /* Smaller fonts for mobile */
   .font-mono { font-size: 11px; }
-  /* Touch-friendly tap targets */
-  button, [role="button"] { min-height: 36px; }
+  /* Touch-friendly tap targets — Apple HIG recommends 44px */
+  button, [role="button"], select { min-height: 36px; }
   /* Fix bottom bar overlap with mobile browser chrome */
   .pb-safe { padding-bottom: env(safe-area-inset-bottom, 8px); }
-  /* Narrower padding */
-  .px-4 { padding-left: 0.75rem; padding-right: 0.75rem; }
-  .px-6 { padding-left: 1rem; padding-right: 1rem; }
+  /* Ensure tables are scrollable */
+  table { display: block; overflow-x: auto; -webkit-overflow-scrolling: touch; }
+  /* Prevent content overflow */
+  pre, code { word-break: break-all; }
 }
 
 /* Shared */

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,21 @@ button, [role="button"], a[href], summary { cursor: pointer; }
 ::-webkit-scrollbar-track { background: #0a0a0f; }
 ::-webkit-scrollbar-thumb { background: #2a2a3e; border-radius: 3px; }
 
+/* Mobile optimizations */
+@media (max-width: 640px) {
+  /* Prevent text size adjust on orientation change */
+  html { -webkit-text-size-adjust: 100%; }
+  /* Smaller fonts for mobile */
+  .font-mono { font-size: 11px; }
+  /* Touch-friendly tap targets */
+  button, [role="button"] { min-height: 36px; }
+  /* Fix bottom bar overlap with mobile browser chrome */
+  .pb-safe { padding-bottom: env(safe-area-inset-bottom, 8px); }
+  /* Narrower padding */
+  .px-4 { padding-left: 0.75rem; padding-right: 0.75rem; }
+  .px-6 { padding-left: 1rem; padding-right: 1rem; }
+}
+
 /* Shared */
 @keyframes agent-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
 @keyframes blink { 50% { opacity: 0; } }
@@ -34,6 +49,10 @@ button, [role="button"], a[href], summary { cursor: pointer; }
   75% { transform: scaleX(0.15); }
   100% { transform: scaleX(1); }
 }
+
+/* Hide scrollbar for nav */
+.scrollbar-hide::-webkit-scrollbar { display: none; }
+.scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
 
 /* Hover preview card */
 @keyframes fadeSlideIn { from { opacity: 0; transform: translateX(20px); } to { opacity: 1; transform: translateX(0); } }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -12,17 +12,18 @@ const hostParam = params.get("host"); // e.g. "white.local:3456"
 /** Whether we're running in remote mode */
 export const isRemote = !!hostParam;
 
+/** Resolve base path from Vite config (strips trailing slash) */
+const basePath = (import.meta.env.BASE_URL || "/").replace(/\/$/, "");
+
 /** Build full URL for fetch() calls */
 export function apiUrl(path: string): string {
-  if (!hostParam) return path;
-  return `https://${hostParam}${path}`;
+  if (hostParam) return `https://${hostParam}${path}`;
+  return `${basePath}${path}`;
 }
 
 /** WebSocket URL */
 export function wsUrl(path: string): string {
-  if (!hostParam) {
-    const proto = location.protocol === "https:" ? "wss:" : "ws:";
-    return `${proto}//${location.host}${path}`;
-  }
-  return `wss://${hostParam}${path}`;
+  if (hostParam) return `wss://${hostParam}${path}`;
+  const proto = location.protocol === "https:" ? "wss:" : "ws:";
+  return `${proto}//${location.host}${basePath}${path}`;
 }

--- a/src/lib/apiFetch.ts
+++ b/src/lib/apiFetch.ts
@@ -1,0 +1,53 @@
+/**
+ * Centralized API fetch with error handling.
+ * Echo's review #2: reduce silent failures across all views.
+ */
+
+import { apiUrl } from "./api";
+import { getAuthToken } from "../components/PinLock";
+
+interface ApiOptions extends RequestInit {
+  /** Skip auth header (e.g. for pin-verify) */
+  noAuth?: boolean;
+}
+
+/** Fetch from MAW API with auth token and consistent error handling */
+export async function apiFetch<T = any>(path: string, options: ApiOptions = {}): Promise<T> {
+  const { noAuth, ...fetchOpts } = options;
+
+  const headers: Record<string, string> = {
+    ...(fetchOpts.headers as Record<string, string> || {}),
+  };
+
+  // Add auth token if available
+  if (!noAuth) {
+    const token = getAuthToken();
+    if (token) headers["Authorization"] = `Bearer ${token}`;
+  }
+
+  // Add content-type for POST/PUT
+  if (fetchOpts.body && !headers["Content-Type"]) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const res = await fetch(apiUrl(path), { ...fetchOpts, headers });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new ApiError(res.status, body || res.statusText, path);
+  }
+
+  return res.json();
+}
+
+/** Typed API error */
+export class ApiError extends Error {
+  constructor(
+    public status: number,
+    public body: string,
+    public path: string,
+  ) {
+    super(`API ${status}: ${body} (${path})`);
+    this.name = "ApiError";
+  }
+}

--- a/src/lib/cache/__tests__/bus.test.ts
+++ b/src/lib/cache/__tests__/bus.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'bun:test';
+import { installDomMocks } from './setup';
+
+installDomMocks();
+
+const { cacheBus } = await import('../bus');
+
+describe('cacheBus', () => {
+  it('delivers invalidation events to listeners', () => {
+    const events: string[] = [];
+    const off = cacheBus.on((ev) => { events.push(ev.tag); });
+    cacheBus.invalidate('menu');
+    cacheBus.invalidate('stats');
+    off();
+    cacheBus.invalidate('menu'); // post-off: should not deliver
+    expect(events).toEqual(['menu', 'stats']);
+  });
+
+  it('mirrors events to localStorage for cross-tab', () => {
+    cacheBus.invalidate('oracles');
+    const raw = (globalThis as unknown as { localStorage: Storage }).localStorage.getItem('oracle_cache_bus_v1');
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw!);
+    expect(parsed.tag).toBe('oracles');
+    expect(typeof parsed.at).toBe('number');
+  });
+
+  it('attachCrossTab returns an unsubscribe function', () => {
+    const off = cacheBus.attachCrossTab();
+    expect(typeof off).toBe('function');
+    off();
+  });
+});

--- a/src/lib/cache/__tests__/cached.test.ts
+++ b/src/lib/cache/__tests__/cached.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { installDomMocks, resetDomMocks } from './setup';
+
+installDomMocks('v1.0.0+test');
+
+const { cached, __resetCachedForTests } = await import('../cached');
+const { cacheBus } = await import('../bus');
+const { localStore } = await import('../local-store');
+
+function sleep(ms: number) { return new Promise((r) => setTimeout(r, ms)); }
+
+describe('cached()', () => {
+  beforeEach(async () => {
+    resetDomMocks();
+    __resetCachedForTests();
+    await localStore.clear();
+  });
+
+  it('fetches on first call and caches', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return { n: calls }; };
+    const a = await cached('k', 10_000, fetcher);
+    const b = await cached('k', 10_000, fetcher);
+    expect(a.n).toBe(1);
+    expect(b.n).toBe(1); // served from cache
+    expect(calls).toBe(1);
+  });
+
+  it('re-fetches after TTL expires (stale-while-revalidate)', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    const v1 = await cached('swr', 5, fetcher);
+    expect(v1).toBe(1);
+    await sleep(10);
+    // Stale: returns cached value immediately but triggers background refetch.
+    const v2 = await cached('swr', 5, fetcher);
+    expect(v2).toBe(1);
+    // Wait for background refetch to finish.
+    await sleep(20);
+    const v3 = await cached('swr', 10_000, fetcher);
+    expect(v3).toBe(2);
+    expect(calls).toBe(2);
+  });
+
+  it('version mismatch invalidates entry', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('vk', 10_000, fetcher);
+    expect(calls).toBe(1);
+
+    // Simulate a new build version.
+    (globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = 'v2.0.0+test';
+    const v = await cached('vk', 10_000, fetcher);
+    expect(v).toBe(2);
+    expect(calls).toBe(2);
+
+    (globalThis as unknown as { __APP_VERSION__: string }).__APP_VERSION__ = 'v1.0.0+test';
+  });
+
+  it('cacheBus.invalidate(tag) drops tagged entries', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('menu-a', 10_000, fetcher, { tag: 'menu' });
+    await cached('menu-b', 10_000, fetcher, { tag: 'menu' });
+    expect(calls).toBe(2);
+
+    cacheBus.invalidate('menu');
+    // Allow async listeners to run.
+    await sleep(5);
+
+    const v = await cached('menu-a', 10_000, fetcher, { tag: 'menu' });
+    expect(v).toBe(3);
+  });
+
+  it('ttl <= 0 bypasses the cache', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; return calls; };
+    await cached('nocache', 0, fetcher);
+    await cached('nocache', 0, fetcher);
+    expect(calls).toBe(2);
+  });
+
+  it('de-dupes concurrent initial fetches', async () => {
+    let calls = 0;
+    const fetcher = async () => { calls++; await sleep(20); return 'x'; };
+    const [a, b, c] = await Promise.all([
+      cached('dedup', 10_000, fetcher),
+      cached('dedup', 10_000, fetcher),
+      cached('dedup', 10_000, fetcher),
+    ]);
+    expect(a).toBe('x');
+    expect(b).toBe('x');
+    expect(c).toBe('x');
+    expect(calls).toBe(1);
+  });
+});

--- a/src/lib/cache/__tests__/local-store.test.ts
+++ b/src/lib/cache/__tests__/local-store.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { installDomMocks, resetDomMocks } from './setup';
+
+installDomMocks();
+
+// Import after mocks are installed.
+const { localStore, estimateBytes } = await import('../local-store');
+
+describe('localStore', () => {
+  beforeEach(() => { resetDomMocks(); });
+
+  it('round-trips an entry', async () => {
+    await localStore.set('k1', { v: 'v0', ts: 1, ttl: 1000, data: { hello: 'world' } });
+    const got = await localStore.get<{ hello: string }>('k1');
+    expect(got?.data.hello).toBe('world');
+    expect(got?.ttl).toBe(1000);
+  });
+
+  it('returns null for missing keys', async () => {
+    expect(await localStore.get('missing')).toBeNull();
+  });
+
+  it('deletes entries', async () => {
+    await localStore.set('k2', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.del('k2');
+    expect(await localStore.get('k2')).toBeNull();
+  });
+
+  it('keys() returns only cache-prefixed keys', async () => {
+    await localStore.set('a', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.set('b', { v: 'v0', ts: 1, ttl: 1, data: 2 });
+    const keys = await localStore.keys();
+    expect(keys.sort()).toEqual(['a', 'b']);
+  });
+
+  it('clear() removes all cache entries', async () => {
+    await localStore.set('a', { v: 'v0', ts: 1, ttl: 1, data: 1 });
+    await localStore.clear();
+    expect((await localStore.keys()).length).toBe(0);
+  });
+
+  it('estimateBytes grows with payload', () => {
+    expect(estimateBytes('x')).toBeGreaterThan(0);
+    expect(estimateBytes('xxxxxxxxxx')).toBeGreaterThan(estimateBytes('x'));
+  });
+});

--- a/src/lib/cache/__tests__/setup.ts
+++ b/src/lib/cache/__tests__/setup.ts
@@ -1,0 +1,35 @@
+// Minimal DOM-ish mocks for bun:test — only what the cache module touches.
+
+class MemoryStorage {
+  private store = new Map<string, string>();
+  get length() { return this.store.size; }
+  key(i: number): string | null {
+    return Array.from(this.store.keys())[i] ?? null;
+  }
+  getItem(k: string): string | null { return this.store.get(k) ?? null; }
+  setItem(k: string, v: string): void { this.store.set(k, String(v)); }
+  removeItem(k: string): void { this.store.delete(k); }
+  clear(): void { this.store.clear(); }
+}
+
+export function installDomMocks(version = 'v0.0.0+test'): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  g.__APP_VERSION__ = version;
+  g.localStorage = new MemoryStorage();
+  g.window = {
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  };
+  g.indexedDB = undefined; // force localStore path; idb tested separately
+  g.Blob = class MockBlob {
+    size: number;
+    constructor(parts: unknown[]) {
+      this.size = parts.reduce<number>((sum, p) => sum + (typeof p === 'string' ? p.length : 0), 0);
+    }
+  } as unknown as typeof Blob;
+}
+
+export function resetDomMocks(): void {
+  const g = globalThis as unknown as Record<string, unknown>;
+  (g.localStorage as MemoryStorage | undefined)?.clear();
+}

--- a/src/lib/cache/bus.ts
+++ b/src/lib/cache/bus.ts
@@ -1,0 +1,55 @@
+// Simple pub/sub bus for cache invalidation. Components fire
+// `cacheBus.invalidate('menu')` after a write; cached-wrapped readers
+// listen and drop any entry whose tag matches.
+
+import type { InvalidationEvent } from './types';
+
+type Listener = (ev: InvalidationEvent) => void;
+
+class CacheBus {
+  private listeners = new Set<Listener>();
+
+  /** Fire an invalidation event for `tag`. Also mirrors to other tabs via storage event. */
+  invalidate(tag: string): void {
+    const ev: InvalidationEvent = { tag, at: Date.now() };
+    for (const fn of this.listeners) {
+      try { fn(ev); } catch { /* ignore */ }
+    }
+    // Cross-tab: bump a well-known localStorage key so other tabs' `storage`
+    // listeners can pick it up and re-broadcast locally.
+    try {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem('oracle_cache_bus_v1', JSON.stringify(ev));
+      }
+    } catch { /* ignore */ }
+  }
+
+  on(fn: Listener): () => void {
+    this.listeners.add(fn);
+    return () => { this.listeners.delete(fn); };
+  }
+
+  /** Rebroadcast a cross-tab storage event locally. */
+  private replay(raw: string | null): void {
+    if (!raw) return;
+    try {
+      const ev = JSON.parse(raw) as InvalidationEvent;
+      if (!ev || typeof ev.tag !== 'string') return;
+      for (const fn of this.listeners) {
+        try { fn(ev); } catch { /* ignore */ }
+      }
+    } catch { /* ignore */ }
+  }
+
+  /** Wire `storage` event listener — call once at app start. */
+  attachCrossTab(): () => void {
+    if (typeof window === 'undefined') return () => {};
+    const handler = (e: StorageEvent) => {
+      if (e.key === 'oracle_cache_bus_v1') this.replay(e.newValue);
+    };
+    window.addEventListener('storage', handler);
+    return () => window.removeEventListener('storage', handler);
+  }
+}
+
+export const cacheBus = new CacheBus();

--- a/src/lib/cache/cached.ts
+++ b/src/lib/cache/cached.ts
@@ -1,0 +1,96 @@
+// cached() — stale-while-revalidate wrapper around a fetcher.
+//   fresh (age < ttl)  → return cached, no refetch.
+//   stale (age ≥ ttl)  → return cached AND kick off a background refetch.
+//   missing / version mismatch → await fetcher, write, return.
+//   cacheBus.invalidate(tag) drops every entry with that tag.
+// Storage: auto (local if ≤50KB, else idb). Override via policy.store.
+
+import type { CacheEntry, CachePolicy } from './types';
+import { localStore, estimateBytes } from './local-store';
+import { idbStore } from './idb-store';
+import { cacheBus } from './bus';
+
+const SIZE_THRESHOLD_BYTES = 50 * 1024;
+
+function appVersion(): string {
+  try { return typeof __APP_VERSION__ !== 'undefined' ? __APP_VERSION__ : 'dev'; }
+  catch { return 'dev'; }
+}
+
+// tag → keys index (for O(1) tag invalidation); inflight map (de-dupes concurrent fetchers).
+const tagIndex = new Map<string, Set<string>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+cacheBus.on(async (ev) => {
+  const keys = tagIndex.get(ev.tag);
+  if (!keys || keys.size === 0) return;
+  const snapshot = Array.from(keys);
+  keys.clear();
+  for (const k of snapshot) {
+    try { await localStore.del(k); } catch { /* ignore */ }
+    try { await idbStore.del(k); } catch { /* ignore */ }
+    inflight.delete(k);
+  }
+});
+
+async function readEntry<T>(key: string): Promise<CacheEntry<T> | null> {
+  return (await localStore.get<T>(key)) ?? (await idbStore.get<T>(key));
+}
+
+async function writeEntry<T>(key: string, entry: CacheEntry<T>, policy: CachePolicy): Promise<void> {
+  if (policy.store === 'idb') { await idbStore.set(key, entry); return; }
+  if (policy.store === 'local') { await localStore.set(key, entry); return; }
+  if (estimateBytes(entry.data) > SIZE_THRESHOLD_BYTES) { await idbStore.set(key, entry); return; }
+  try { await localStore.set(key, entry); }
+  catch { await idbStore.set(key, entry); }
+}
+
+async function fetchAndStore<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): Promise<T> {
+  const existing = inflight.get(key) as Promise<T> | undefined;
+  if (existing) return existing;
+  const p = (async () => {
+    const data = await fetcher();
+    const entry: CacheEntry<T> = { v: appVersion(), ts: Date.now(), ttl: ttlMs, tag: policy.tag, data };
+    try { await writeEntry(key, entry, policy); } catch { /* ignore */ }
+    return data;
+  })();
+  inflight.set(key, p);
+  try { return await p; } finally { inflight.delete(key); }
+}
+
+function refreshInBackground<T>(key: string, ttlMs: number, fetcher: () => Promise<T>, policy: CachePolicy): void {
+  if (inflight.has(key)) return;
+  const p = fetchAndStore(key, ttlMs, fetcher, policy).catch(() => { /* swallow */ });
+  inflight.set(key, p);
+  void p.finally(() => { inflight.delete(key); });
+}
+
+/** Wrap `fetcher` with stale-while-revalidate caching keyed by `key`. */
+export async function cached<T>(
+  key: string,
+  ttlMs: number,
+  fetcher: () => Promise<T>,
+  policy: CachePolicy = {},
+): Promise<T> {
+  if (policy.tag) {
+    let set = tagIndex.get(policy.tag);
+    if (!set) { set = new Set(); tagIndex.set(policy.tag, set); }
+    set.add(key);
+  }
+  if (ttlMs <= 0) return fetcher();
+
+  const entry = await readEntry<T>(key);
+  const v = appVersion();
+  if (entry && entry.v === v) {
+    if (Date.now() - entry.ts < ttlMs) return entry.data;
+    refreshInBackground(key, ttlMs, fetcher, policy);
+    return entry.data;
+  }
+  return fetchAndStore(key, ttlMs, fetcher, policy);
+}
+
+/** Test-only reset. */
+export function __resetCachedForTests(): void {
+  tagIndex.clear();
+  inflight.clear();
+}

--- a/src/lib/cache/globals.d.ts
+++ b/src/lib/cache/globals.d.ts
@@ -1,0 +1,1 @@
+declare const __APP_VERSION__: string;

--- a/src/lib/cache/idb-store.ts
+++ b/src/lib/cache/idb-store.ts
@@ -1,0 +1,94 @@
+// IndexedDB adapter for the client cache — used for larger payloads
+// (>50KB) that would bloat localStorage. Single object-store keyed by
+// string. Gracefully no-ops when IndexedDB is unavailable.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const DB_NAME = 'oracle_cache_v1';
+const STORE = 'entries';
+
+let dbPromise: Promise<IDBDatabase | null> | null = null;
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (dbPromise) return dbPromise;
+  dbPromise = new Promise((resolve) => {
+    try {
+      if (typeof indexedDB === 'undefined') { resolve(null); return; }
+      const req = indexedDB.open(DB_NAME, 1);
+      req.onupgradeneeded = () => {
+        const db = req.result;
+        if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE);
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+      req.onblocked = () => resolve(null);
+    } catch {
+      resolve(null);
+    }
+  });
+  return dbPromise;
+}
+
+function tx(db: IDBDatabase, mode: IDBTransactionMode): IDBObjectStore {
+  return db.transaction(STORE, mode).objectStore(STORE);
+}
+
+function promisify<T>(req: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    req.onsuccess = () => resolve(req.result);
+    req.onerror = () => reject(req.error);
+  });
+}
+
+export const idbStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const db = await openDb();
+    if (!db) return null;
+    try {
+      const val = await promisify<unknown>(tx(db, 'readonly').get(key));
+      if (!val || typeof val !== 'object') return null;
+      const e = val as CacheEntry<T>;
+      if (typeof e.ts !== 'number' || typeof e.ttl !== 'number') return null;
+      return e;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').put(entry, key)); } catch {
+      throw new Error('idbStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').delete(key)); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const db = await openDb();
+    if (!db) return [];
+    try {
+      const req = tx(db, 'readonly').getAllKeys();
+      const arr = await promisify<IDBValidKey[]>(req);
+      return arr.map((k) => String(k));
+    } catch {
+      return [];
+    }
+  },
+
+  async clear(): Promise<void> {
+    const db = await openDb();
+    if (!db) return;
+    try { await promisify(tx(db, 'readwrite').clear()); } catch { /* ignore */ }
+  },
+};
+
+/** Reset the module singleton — test-only; not exported from the barrel. */
+export function __resetIdbForTests(): void {
+  dbPromise = null;
+}

--- a/src/lib/cache/index.ts
+++ b/src/lib/cache/index.ts
@@ -1,0 +1,6 @@
+// Barrel for the client cache module.
+export { cached } from './cached';
+export { cacheBus } from './bus';
+export { localStore } from './local-store';
+export { idbStore } from './idb-store';
+export type { CacheEntry, CachePolicy, InvalidationEvent, CacheStore } from './types';

--- a/src/lib/cache/local-store.ts
+++ b/src/lib/cache/local-store.ts
@@ -1,0 +1,87 @@
+// localStorage adapter for the client cache.
+//
+// Keys are namespaced under `oracle_cache/v1:` so the store is easy to spot
+// in devtools and can be wiped atomically via `clear()`.
+
+import type { CacheEntry, CacheStore } from './types';
+
+const PREFIX = 'oracle_cache/v1:';
+
+function storage(): Storage | null {
+  try {
+    if (typeof localStorage === 'undefined') return null;
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export const localStore: CacheStore = {
+  async get<T>(key: string): Promise<CacheEntry<T> | null> {
+    const ls = storage();
+    if (!ls) return null;
+    try {
+      const raw = ls.getItem(PREFIX + key);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw) as CacheEntry<T>;
+      if (!parsed || typeof parsed.ts !== 'number' || typeof parsed.ttl !== 'number') return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  },
+
+  async set<T>(key: string, entry: CacheEntry<T>): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      ls.setItem(PREFIX + key, JSON.stringify(entry));
+    } catch {
+      // Quota exceeded or other failure — swallow; caller may fall back to idb.
+      throw new Error('localStore:set failed');
+    }
+  },
+
+  async del(key: string): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try { ls.removeItem(PREFIX + key); } catch { /* ignore */ }
+  },
+
+  async keys(): Promise<string[]> {
+    const ls = storage();
+    if (!ls) return [];
+    const out: string[] = [];
+    try {
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) out.push(k.slice(PREFIX.length));
+      }
+    } catch { /* ignore */ }
+    return out;
+  },
+
+  async clear(): Promise<void> {
+    const ls = storage();
+    if (!ls) return;
+    try {
+      const doomed: string[] = [];
+      for (let i = 0; i < ls.length; i++) {
+        const k = ls.key(i);
+        if (k && k.startsWith(PREFIX)) doomed.push(k);
+      }
+      for (const k of doomed) ls.removeItem(k);
+    } catch { /* ignore */ }
+  },
+};
+
+/** Estimate the byte size of a value once JSON-encoded. */
+export function estimateBytes(value: unknown): number {
+  try {
+    return new Blob([JSON.stringify(value)]).size;
+  } catch {
+    try { return JSON.stringify(value).length * 2; } catch { return 0; }
+  }
+}
+
+export const LOCAL_STORE_PREFIX = PREFIX;

--- a/src/lib/cache/types.ts
+++ b/src/lib/cache/types.ts
@@ -1,0 +1,34 @@
+// Client-side API cache — shared types.
+
+export interface CacheEntry<T = unknown> {
+  /** App build version (from __APP_VERSION__) at write time. */
+  v: string;
+  /** ISO epoch ms when this entry was written. */
+  ts: number;
+  /** TTL in ms — entry is fresh while `now - ts < ttl`. */
+  ttl: number;
+  /** Invalidation tag (optional). */
+  tag?: string;
+  /** The cached value. */
+  data: T;
+}
+
+export interface CachePolicy {
+  /** Invalidation tag for bulk clear via cacheBus. */
+  tag?: string;
+  /** Force a specific backing store. Default: auto — local first, idb if payload > 50KB. */
+  store?: 'local' | 'idb';
+}
+
+export interface InvalidationEvent {
+  tag: string;
+  at: number;
+}
+
+export interface CacheStore {
+  get<T>(key: string): Promise<CacheEntry<T> | null>;
+  set<T>(key: string, entry: CacheEntry<T>): Promise<void>;
+  del(key: string): Promise<void>;
+  keys(): Promise<string[]>;
+  clear(): Promise<void>;
+}

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -104,26 +104,26 @@ const TOOL_ICONS: Record<string, string> = {
  * Human-readable one-liner for what the oracle is doing.
  */
 export function describeActivity(event: FeedEvent): string {
+  const msg = event.message || "";
   switch (event.event) {
     case "PreToolUse": {
       // Message format: "ToolName: details..." or "ToolName ✓"
-      const colonIdx = event.message.indexOf(":");
+      const colonIdx = msg.indexOf(":");
       const tool =
-        colonIdx > 0 ? event.message.slice(0, colonIdx).trim() : event.message.split(" ")[0];
+        colonIdx > 0 ? msg.slice(0, colonIdx).trim() : msg.split(" ")[0] || "Tool";
       const icon = TOOL_ICONS[tool] || "🔧";
-      const detail = colonIdx > 0 ? event.message.slice(colonIdx + 1).trim() : "";
+      const detail = colonIdx > 0 ? msg.slice(colonIdx + 1).trim() : "";
       const short = detail.length > 60 ? detail.slice(0, 57) + "..." : detail;
       return short ? `${icon} ${tool}: ${short}` : `${icon} ${tool}`;
     }
     case "PostToolUse":
     case "PostToolUseFailure": {
       const ok = event.event === "PostToolUse";
-      const tool = event.message.replace(/ [✓✗].*$/, "").trim() || "Tool";
+      const tool = msg.replace(/ [✓✗].*$/, "").trim() || "Tool";
       return ok ? `✓ ${tool} done` : `✗ ${tool} failed`;
     }
     case "UserPromptSubmit": {
-      const short =
-        event.message.length > 60 ? event.message.slice(0, 57) + "..." : event.message;
+      const short = msg.length > 60 ? msg.slice(0, 57) + "..." : msg;
       return `💬 ${short || "New prompt"}`;
     }
     case "SubagentStart":
@@ -135,13 +135,12 @@ export function describeActivity(event: FeedEvent): string {
     case "SessionEnd":
       return `⏹ Session ended`;
     case "Stop": {
-      const short =
-        event.message.length > 60 ? event.message.slice(0, 57) + "..." : event.message;
+      const short = msg.length > 60 ? msg.slice(0, 57) + "..." : msg;
       return `⏹ ${short || "Stopped"}`;
     }
     case "Notification":
-      return `🔔 ${event.message || "Notification"}`;
+      return `🔔 ${msg || "Notification"}`;
     default:
-      return event.message || event.event;
+      return msg || event.event;
   }
 }

--- a/src/lib/feed.ts
+++ b/src/lib/feed.ts
@@ -104,7 +104,8 @@ const TOOL_ICONS: Record<string, string> = {
  * Human-readable one-liner for what the oracle is doing.
  */
 export function describeActivity(event: FeedEvent): string {
-  const msg = event.message || "";
+  if (!event) return "—";
+  const msg = event.message ?? "";
   switch (event.event) {
     case "PreToolUse": {
       // Message format: "ToolName: details..." or "ToolName ✓"

--- a/src/lib/tokens.ts
+++ b/src/lib/tokens.ts
@@ -1,0 +1,31 @@
+// Design tokens shared across studio + vector + canvas.
+// Keep this file small — only tokens that multiple apps consume.
+
+export const LAYOUT = {
+  /** Default max-width for page containers (px). */
+  maxWidth: '1300px',
+  /** Max-width for the full-bleed header row (px). */
+  headerMaxWidth: '1400px',
+  /** Default horizontal padding (Tailwind scale). */
+  px: 6,
+  /** Default vertical padding (Tailwind scale). */
+  py: 6,
+} as const;
+
+export const CHIP_COLORS = {
+  checking: {
+    bg: 'rgba(148, 163, 184, 0.12)',
+    border: 'rgba(148, 163, 184, 0.3)',
+    dot: '#94a3b8',
+  },
+  live: {
+    bg: 'rgba(74, 222, 128, 0.12)',
+    border: 'rgba(74, 222, 128, 0.4)',
+    dot: '#4ade80',
+  },
+  demo: {
+    bg: 'rgba(251, 191, 36, 0.12)',
+    border: 'rgba(251, 191, 36, 0.4)',
+    dot: '#fbbf24',
+  },
+} as const;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,12 @@ import "./index.css";
 import { App } from "./App";
 import { ErrorBoundary } from "./components/ErrorBoundary";
 import { PinLock } from "./components/PinLock";
+import { cacheBus } from "./lib/cache";
+
+// Cross-tab cache invalidation: a write in one tab broadcasts to all others.
+if (typeof window !== "undefined") {
+  cacheBus.attachCrossTab();
+}
 
 createRoot(document.getElementById("root")!).render(
   <ErrorBoundary>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/__tests__"]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   define: {
     __MAW_VERSION__: JSON.stringify(pkg.version),
     __MAW_BUILD__: JSON.stringify(new Date().toLocaleString("sv-SE", { timeZone: "Asia/Bangkok", dateStyle: "short", timeStyle: "short" })),
+    __APP_VERSION__: JSON.stringify(pkg.version),
   },
   root: ".",
   base: "/maw/",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     __MAW_BUILD__: JSON.stringify(new Date().toLocaleString("sv-SE", { timeZone: "Asia/Bangkok", dateStyle: "short", timeStyle: "short" })),
   },
   root: ".",
-  base: "/",
+  base: "/maw/",
   build: {
     outDir: "dist",
     emptyOutDir: true,
@@ -21,9 +21,9 @@ export default defineConfig({
     host: true,
     allowedHosts: ["white.local"],
     proxy: {
-      "/api": "http://white.local:3456",
-      "/ws/pty": { target: "ws://white.local:3456", ws: true },
-      "/ws": { target: "ws://white.local:3456", ws: true },
+      "/maw/api": { target: "http://localhost:3456", rewrite: (path) => path.replace(/^\/maw/, "") },
+      "/maw/ws/pty": { target: "ws://localhost:3456", ws: true, rewrite: (path) => path.replace(/^\/maw/, "") },
+      "/maw/ws": { target: "ws://localhost:3456", ws: true, rewrite: (path) => path.replace(/^\/maw/, "") },
     },
   },
 });

--- a/ψ/inbox/handoff/2026-04-08_00-40_full-consciousness-fleet-deployed.md
+++ b/ψ/inbox/handoff/2026-04-08_00-40_full-consciousness-fleet-deployed.md
@@ -1,0 +1,66 @@
+# Handoff: Full Consciousness Fleet — Deployed & Running 24/7
+
+**Date**: 2026-04-08 00:40 GMT+7
+**Context**: 212k/200k
+
+📡 Session: 5f04a239 | maw-js + maw-ui | ~3h (14:26–00:40 GMT+7)
+
+## Context
+**Oracle**: Labubu (she) | **Human**: Boss (he)
+**Mode**: Full Soul Sync | **Memory**: auto
+
+## What We Did
+
+### 1. Yeast Budding Model (maw-js)
+- `maw bud` — spawn child oracle (tested live)
+- `maw take` — move window between oracles
+- `maw done --archive` — full lifecycle apoptosis
+- Auto soul-sync on done
+
+### 2. Consciousness Loop (maw-js)
+- `maw think` — 7-phase autonomous thinking (reflect→wonder→soul→dream→aspire→propose)
+- `maw think --fleet` — all 4 oracles think in parallel (tested: 280s)
+- Consciousness cron `0 */3 * * *` — 8 cycles/day, 3-phase (think→cross→learn)
+
+### 3. Oracle Weakness Fixes
+- Labubu: 2 success beliefs promoted (#14, #15)
+- Neo: 5 first learnings created
+- Pulse: heartbeat.sh LIVE + healthchecks.io + cron
+- Echo: belief-tracker 5/7 upgraded to pattern
+
+### 4. Dashboard (maw-ui + maw-js API)
+- `/api/consciousness` — all oracle beliefs/vision/goals/proposals
+- `/api/health/collect` + `/health/history` + `/health/latest` — VPS metrics → SQLite
+- `/api/maw-log` — OracleNet chat history
+- ConsciousnessView.tsx — 🧠 Think page with oracle cards + tabs
+- Mission Control button — 🧠 Consciousness shortcut
+
+### 5. Echo Cross-Repo Research
+- Oracle ψ/ audit: 4280 files/63MB (labubu), concurrent write risk identified
+- maw-ui WS vs polling: 7 poll-only components, 6 WS-powered
+- Belief tracker: 5/7 beliefs upgraded hypothesis→pattern
+
+## Live Infrastructure
+- Pulse heartbeat: `*/5 * * * *` → healthchecks.io (UUID: 34212051...)
+- Consciousness loop: `0 */3 * * *` → fleet think + cross-pollinate + learn
+- Health snapshots: 106+ in SQLite, auto-pruned 7 days
+- Dashboard: http://76.13.221.42/maw/
+
+## Commits
+- `66c5d7f` — feat: yeast budding + consciousness loop (maw-js)
+- `7956342` — feat: consciousness dashboard, health API, chat log API (maw-js)
+- `b4f0b1a` — feat: Consciousness view + nav (maw-ui)
+
+## Pending
+- [ ] Children sessions reset at 6pm UTC — resume Neo/Pulse/Echo missions
+- [ ] Neo: Wire ChatView to OracleNet (mission sent, waiting session reset)
+- [ ] Pulse: Health timeline graph on MonitoringView
+- [ ] Echo: 3rd study on external repo for beliefs #3, #6
+- [ ] Webhook alert setup (LINE/Discord — Boss needs to provide URL)
+- [ ] SaaS packaging
+
+## Next Session
+- [ ] `/recap` — orient
+- [ ] Check consciousness-cron.log — did the 3am cycle run?
+- [ ] Check children progress after session limit reset
+- [ ] Review oracle proposals at #consciousness page


### PR DESCRIPTION
Canonical-**main** landing of the mobile on-screen control-key bar for driving TUIs from a phone — adds tappable ↑ ↓ ← → Enter Tab Esc Space and ⌃C keys above the soft keyboard.

**Already LIVE** — served on the VPS since **2026-06-06 10:03** via overlay-deploy (`--base=/maw/` build → /opt/maw-dashboard). This PR is the canonical-main landing of that already-shipped fix so the source-of-truth tree carries the marker (no parallel-line drift).

Stacks naturally on the **#55 / #47** mobile-composer line (same `echo/...` terminal-mobile series, all base=main) — expected and correct; commit `2d9d105` sits on top of `825e6cf` (⇥ accept+submit) and `a927c0b` (⇥ accept-suggestion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)