### PR TITLE
feat(dashboard): 📚 KB nav link to TconHR guide (clean split off #61)

### DIFF
--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -67,7 +67,9 @@ interface StatusBarProps {
   children?: ReactNode;
 }
 
-const NAV_ITEMS = [
+type NavItem = { href: string; label: string; id: string; external?: boolean };
+
+const NAV_ITEMS: NavItem[] = [
   { href: "#mission", label: "Mission", id: "mission" },
   { href: "#dashboard", label: "Dashboard", id: "dashboard" },
   { href: "#fleet", label: "Fleet", id: "fleet" },
@@ -82,6 +84,9 @@ const NAV_ITEMS = [
   // Board, Loops, Jarvis, Fame, BoB removed — no upstream backends
   // (from BankCurfew's fork, PR #19). Files kept per Nothing is Deleted.
   { href: "#config", label: "Config", id: "config" },
+  // External KB link — opens the (already auth-gated) TconHR guide hub in a new tab.
+  // Absolute same-origin path → existing dashboard login cookie is sent → no re-login on mobile.
+  { href: "/maw/tconsiam/guides/tconhr.html", label: "📚 KB", id: "kb", external: true },
 ];
 
 const isTouch = typeof window !== "undefined" && ("ontouchstart" in window || navigator.maxTouchPoints > 0);
@@ -187,19 +192,32 @@ export const StatusBar = memo(function StatusBar({ connected, agentCount, sessio
             )}
           </button>
         )}
-        {NAV_ITEMS.map((item) => (
-          <a
-            key={item.id}
-            href={item.href}
-            className={`transition-colors whitespace-nowrap ${
-              activeView === item.id
-                ? "text-cyan-400 font-bold"
-                : "text-white/50 hover:text-white/80"
-            }`}
-          >
-            {item.label}
-          </a>
-        ))}
+        {NAV_ITEMS.map((item) =>
+          item.external ? (
+            <a
+              key={item.id}
+              href={item.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="transition-colors whitespace-nowrap text-amber-300/70 hover:text-amber-200"
+              title="TconHR KB guide (opens gated doc — same login)"
+            >
+              {item.label}
+            </a>
+          ) : (
+            <a
+              key={item.id}
+              href={item.href}
+              className={`transition-colors whitespace-nowrap ${
+                activeView === item.id
+                  ? "text-cyan-400 font-bold"
+                  : "text-white/50 hover:text-white/80"
+              }`}
+            >
+              {item.label}
+            </a>
+          )
+        )}
       </nav>
     </header>
   );


### PR DESCRIPTION
Clean recut of the **KB-nav** feature from PR #61 onto current `main` (`e0c9983`).

## Why a new PR
#61 sits on a 100-commits-behind base and bundles unrelated dashboard work (Tokens panel, PageShell wraps, statusbar kill-switch, worktree-cache). This PR carries **only** the shippable, isolated piece.

## What it does
Adds a `📚 KB` entry to the StatusBar nav → opens the already-auth-gated TconHR guide hub at `/maw/tconsiam/guides/tconhr.html`.
- Absolute same-origin path → existing dashboard login cookie rides along (no re-login on mobile).
- Opens in new tab (`target=_blank rel=noopener noreferrer`), amber-tinted to read as external.
- **Isolated to `StatusBar.tsx`** (1 file, +32/−14). Terminal/TerminalKeyBar untouched.

## Reconcile notes
- Resolved against main's current StatusBar styling — did **not** re-introduce the old-base `min-h-[44px]` touch-target classes (kept the split surgical; main's nav styling preserved).
- Original commit: `eeacd19` (2026-06-06). The remaining #61 dashboard-refactor bundle is parked for separate review (the worktree-cache piece depends on #59's cache layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)